### PR TITLE
Return a representative relation for path

### DIFF
--- a/src/main/cypher/golr-loader/case-disease.yaml
+++ b/src/main/cypher/golr-loader/case-disease.yaml
@@ -1,14 +1,14 @@
 query: |
         MATCH path=(object:disease)<-[relation:RO:0003301]-(model)-[:RO:0001000]->(subject:case)
         RETURN path,
-        subject, object,
+        subject, object, relation,
         'case' AS subject_category,
         'disease' AS object_category,
-        'indirect' AS qualifier
+        'direct' AS qualifier
         UNION ALL
-        MATCH path=(object:disease)<-[:RO:0002200]-(subject:case)
+        MATCH path=(object:disease)<-[relation:RO:0002200]-(subject:case)
         RETURN path,
-        subject, object,
+        subject, object, relation,
         'case' AS subject_category,
         'disease' AS object_category,
-        'indirect' AS qualifier
+        'direct' AS qualifier

--- a/src/main/cypher/golr-loader/case-genotype.yaml
+++ b/src/main/cypher/golr-loader/case-genotype.yaml
@@ -1,7 +1,7 @@
 query: |
-        MATCH path=(model)-[:RO:0001000*0..1]->(subject:case)-[:GENO:0000222]->(object:genotype)
+        MATCH path=(model)-[:RO:0001000*0..1]->(subject:case)-[relation:GENO:0000222]->(object:genotype)
         RETURN path,
-        subject, object, NULL as relation,
+        subject, object, relation,
         'case' AS subject_category,
         'genotype' AS object_category,
-        'indirect' AS qualifier
+        'direct' AS qualifier

--- a/src/main/cypher/golr-loader/case-variant.yaml
+++ b/src/main/cypher/golr-loader/case-variant.yaml
@@ -1,8 +1,8 @@
 query: |
-        MATCH path=(model)-[:RO:0001000*0..1]->(subject:case)-[:GENO:0000222]->(genotype:genotype)-[:BFO:0000051!*]->(object)
+        MATCH path=(model)-[:RO:0001000*0..1]->(subject:case)-[relation:GENO:0000222]->(genotype:genotype)-[:BFO:0000051!*]->(object)
         WHERE ((object:`sequence feature` AND NOT object:gene) OR object:`variant locus`) OR object:`reagent targeted gene`
         RETURN path,
-        subject, object,
+        subject, object, relation,
         'case' AS subject_category,
         'variant' AS object_category,
-        'direct' AS qualifier
+        'inferred through intrinsic genotype' AS qualifier

--- a/src/main/cypher/golr-loader/disease-pathway.yaml
+++ b/src/main/cypher/golr-loader/disease-pathway.yaml
@@ -5,7 +5,7 @@ query: |
         subject, object, relation,
         'disease' AS subject_category,
         'pathway' AS object_category,
-        'inferred' AS qualifier
+        'inferred through joining gene disease and gene pathway associations' AS qualifier
         UNION ALL
         MATCH path=(subject:disease)<-[relation:RO:0002418!]-(object:pathway)
         RETURN path,

--- a/src/main/cypher/golr-loader/disease-phenotype.yaml
+++ b/src/main/cypher/golr-loader/disease-phenotype.yaml
@@ -2,12 +2,12 @@ query: |
         MATCH path=(subject:disease)-[relation:RO:0002200|RO:0002610|RO:0002326!]->(object:Phenotype)
         OPTIONAL MATCH (assoc:association)-[:OBAN:association_has_subject]->(subject),
                        (assoc)-[:OBAN:association_has_object]->(object),
-                       (assoc)-[:OBAN:association_has_predicate]->(has_pheno:ObjectProperty{iri:'http://purl.obolibrary.org/obo/RO_0002200'}),
+                       (assoc)-[:OBAN:association_has_predicate]->(has_pheno:Node{iri:'http://purl.obolibrary.org/obo/RO_0002200'}),
                        (assoc)-[::onset]->(onset)
         WITH path, subject, relation, object, onset
         OPTIONAL MATCH (assoc:association)-[:OBAN:association_has_subject]->(subject),
                        (assoc)-[:OBAN:association_has_object]->(object),
-                       (assoc)-[:OBAN:association_has_predicate]->(has_pheno:ObjectProperty{iri:'http://purl.obolibrary.org/obo/RO_0002200'}),
+                       (assoc)-[:OBAN:association_has_predicate]->(has_pheno:Node{iri:'http://purl.obolibrary.org/obo/RO_0002200'}),
                        (assoc)-[::frequencyOfPhenotype]->(frequency)
         RETURN path, onset, frequency,
         subject, object, relation,

--- a/src/main/cypher/golr-loader/gene-disease.yaml
+++ b/src/main/cypher/golr-loader/gene-disease.yaml
@@ -3,31 +3,31 @@ query: |
         WITH feature, COUNT(DISTINCT(locus)) as gene_count
         WHERE gene_count = 1
         AND NOT feature:snv
-        MATCH path=(subject:gene)<-[geno:GENO:0000418|GENO:0000639!]-(feature)-[:RO:0002200|RO:0002610|RO:0002326|RO:0003302!]->(object:disease)
+        MATCH path=(subject:gene)<-[geno:GENO:0000418|GENO:0000639!]-(feature)-[relation:RO:0002200|RO:0002610|RO:0002326|RO:0003302!]->(object:disease)
         RETURN path,
-        subject, object,
+        subject, object, relation,
         'gene' AS subject_category,
         'disease' AS object_category,
-        'inferred' as qualifier
+        'inferred through variant' as qualifier
         UNION ALL
-        MATCH path=(subject:gene)<-[geno:GENO:0000418|GENO:0000639!]-(feature:snv)-[:RO:0002200|RO:0002610|RO:0002326|RO:0003302!]->(object:disease)
+        MATCH path=(subject:gene)<-[geno:GENO:0000418|GENO:0000639!]-(feature:snv)-[relation:RO:0002200|RO:0002610|RO:0002326|RO:0003302!]->(object:disease)
         RETURN path,
-        subject, object,
+        subject, object, relation,
         'gene' AS subject_category,
         'disease' AS object_category,
-        'inferred' as qualifier
+        'inferred through variant' as qualifier
         UNION ALL
-        MATCH path=(subject:gene)<-[:GENO:0000418|GENO:0000639!]-(variant)<-[:BFO:0000051!*]-(genotype:genotype)-[:RO:0002200|RO:0002610|RO:0002326|RO:0003302!]->(object:disease)
+        MATCH path=(subject:gene)<-[:GENO:0000418|GENO:0000639!]-(variant)<-[:BFO:0000051!*]-(genotype:genotype)-[relation:RO:0002200|RO:0002610|RO:0002326|RO:0003302!]->(object:disease)
         RETURN path,
-        subject, object,
+        subject, object, relation,
         'gene' AS subject_category,
         'disease' AS object_category,
-        'inferred' as qualifier
+        'inferred through genotype' as qualifier
         UNION ALL
-        MATCH path=(subject:gene)<-[:GENO:0000418|GENO:0000639!]-(variant)<-[:BFO:0000051!*]-(genotype:genotype)<-[:GENO:0000222|RO:0001000*1..2]-(person)-[rel:RO:0002200!]->(object:disease)
-        WHERE NOT rel.isDefinedBy="https://data.monarchinitiative.org/ttl/udp.ttl"
+        MATCH path=(subject:gene)<-[:GENO:0000418|GENO:0000639!]-(variant)<-[:BFO:0000051!*]-(genotype:genotype)<-[:GENO:0000222|RO:0001000*1..2]-(person)-[relation:RO:0002200!]->(object:disease)
+        WHERE NOT relation.isDefinedBy="https://data.monarchinitiative.org/ttl/udp.ttl"
         RETURN path,
-        subject, object,
+        subject, object, relation,
         'gene' AS subject_category,
         'disease' AS object_category,
-        'inferred' as qualifier
+        'inferred through disease model' as qualifier

--- a/src/main/cypher/golr-loader/gene-phenotype.yaml
+++ b/src/main/cypher/golr-loader/gene-phenotype.yaml
@@ -27,18 +27,18 @@ query: |
         'direct' as qualifier
         UNION ALL
         MATCH path=(subject:gene)<-[:GENO:0000418!*0..1]-(feature)-[:RO:0002200|RO:0002326|RO:0003302!*2..]->(object:Phenotype)
+        MATCH (relation:ObjectProperty{iri:'http://purl.obolibrary.org/obo/RO_0002200'})
         RETURN path,
-        subject, object,
-        NULL as relation,
+        subject, object, relation,
         'gene' AS subject_category,
         'phenotype' AS object_category,
-        'inferred' as qualifier
+        'inferred through variant' as qualifier
         UNION ALL
         MATCH path=(subject:gene)<-[:GENO:0000418!*0..1]-(feature)<-[:BFO:0000051!*]-(genotype:genotype)-[rel:RO:0002200|RO:0002326|RO:0003302!*]->(object:Phenotype)
-        WHERE NOT ANY (relation in rel where relation.isDefinedBy="https://data.monarchinitiative.org/ttl/mgi.ttl" OR relation.isDefinedBy="https://data.monarchinitiative.org/ttl/zfin.ttl")
+        MATCH (relation:ObjectProperty{iri:'http://purl.obolibrary.org/obo/RO_0002200'})
+        WHERE NOT ANY (pheno_rel in rel where pheno_rel.isDefinedBy="https://data.monarchinitiative.org/ttl/mgi.ttl" OR pheno_rel.isDefinedBy="https://data.monarchinitiative.org/ttl/zfin.ttl")
         RETURN path,
-        subject, object,
-        NULL as relation,
+        subject, object, relation,
         'gene' AS subject_category,
         'phenotype' AS object_category,
         'inferred' as qualifier
@@ -51,10 +51,10 @@ query: |
         'inferred' as qualifier
         UNION ALL
         MATCH path=(subject:gene)<-[:GENO:0000418!*0..1]-(feature)<-[:BFO:0000051!*]-(genotype:genotype)<-[:GENO:0000222|RO:0001000*1..2]-(person)-[rel:RO:0002200|RO:0002326!*]->(object:Phenotype)
-        WHERE NOT ANY (relation in rel where relation.isDefinedBy="https://data.monarchinitiative.org/ttl/udp.ttl")
+        MATCH (relation:ObjectProperty{iri:'http://purl.obolibrary.org/obo/RO_0002200'})
+        WHERE NOT ANY (pheno_rel in rel where pheno_rel.isDefinedBy="https://data.monarchinitiative.org/ttl/udp.ttl")
         RETURN path,
-        subject, object,
-        NULL as relation,
+        subject, object, relation,
         'gene' AS subject_category,
         'phenotype' AS object_category,
         'inferred' as qualifier

--- a/src/main/cypher/golr-loader/gene-phenotype.yaml
+++ b/src/main/cypher/golr-loader/gene-phenotype.yaml
@@ -26,16 +26,18 @@ query: |
         'phenotype' AS object_category,
         'direct' as qualifier
         UNION ALL
-        MATCH path=(subject:gene)<-[:GENO:0000418!*0..1]-(feature)-[:RO:0002200|RO:0002326|RO:0003302!*2..]->(object:Phenotype)
         MATCH (relation:ObjectProperty{iri:'http://purl.obolibrary.org/obo/RO_0002200'})
+        WITH relation
+        MATCH path=(subject:gene)<-[:GENO:0000418!*0..1]-(feature)-[:RO:0002200|RO:0002326|RO:0003302!*2..]->(object:Phenotype)
         RETURN path,
         subject, object, relation,
         'gene' AS subject_category,
         'phenotype' AS object_category,
         'inferred through variant' as qualifier
         UNION ALL
-        MATCH path=(subject:gene)<-[:GENO:0000418!*0..1]-(feature)<-[:BFO:0000051!*]-(genotype:genotype)-[rel:RO:0002200|RO:0002326|RO:0003302!*]->(object:Phenotype)
         MATCH (relation:ObjectProperty{iri:'http://purl.obolibrary.org/obo/RO_0002200'})
+        WITH relation
+        MATCH path=(subject:gene)<-[:GENO:0000418!*0..1]-(feature)<-[:BFO:0000051!*]-(genotype:genotype)-[rel:RO:0002200|RO:0002326|RO:0003302!*]->(object:Phenotype)
         WHERE NOT ANY (pheno_rel in rel where pheno_rel.isDefinedBy="https://data.monarchinitiative.org/ttl/mgi.ttl" OR pheno_rel.isDefinedBy="https://data.monarchinitiative.org/ttl/zfin.ttl")
         RETURN path,
         subject, object, relation,
@@ -50,8 +52,9 @@ query: |
         'phenotype' AS object_category,
         'inferred' as qualifier
         UNION ALL
-        MATCH path=(subject:gene)<-[:GENO:0000418!*0..1]-(feature)<-[:BFO:0000051!*]-(genotype:genotype)<-[:GENO:0000222|RO:0001000*1..2]-(person)-[rel:RO:0002200|RO:0002326!*]->(object:Phenotype)
         MATCH (relation:ObjectProperty{iri:'http://purl.obolibrary.org/obo/RO_0002200'})
+        WITH relation
+        MATCH path=(subject:gene)<-[:GENO:0000418!*0..1]-(feature)<-[:BFO:0000051!*]-(genotype:genotype)<-[:GENO:0000222|RO:0001000*1..2]-(person)-[rel:RO:0002200|RO:0002326!*]->(object:Phenotype)
         WHERE NOT ANY (pheno_rel in rel where pheno_rel.isDefinedBy="https://data.monarchinitiative.org/ttl/udp.ttl")
         RETURN path,
         subject, object, relation,

--- a/src/main/cypher/golr-loader/gene-phenotype.yaml
+++ b/src/main/cypher/golr-loader/gene-phenotype.yaml
@@ -26,7 +26,7 @@ query: |
         'phenotype' AS object_category,
         'direct' as qualifier
         UNION ALL
-        MATCH (relation:ObjectProperty{iri:'http://purl.obolibrary.org/obo/RO_0002200'})
+        MATCH (relation:Node{iri:'http://purl.obolibrary.org/obo/RO_0002200'})
         WITH relation
         MATCH path=(subject:gene)<-[:GENO:0000418!*0..1]-(feature)-[:RO:0002200|RO:0002326|RO:0003302!*2..]->(object:Phenotype)
         RETURN path,
@@ -35,7 +35,7 @@ query: |
         'phenotype' AS object_category,
         'inferred through variant' as qualifier
         UNION ALL
-        MATCH (relation:ObjectProperty{iri:'http://purl.obolibrary.org/obo/RO_0002200'})
+        MATCH (relation:Node{iri:'http://purl.obolibrary.org/obo/RO_0002200'})
         WITH relation
         MATCH path=(subject:gene)<-[:GENO:0000418!*0..1]-(feature)<-[:BFO:0000051!*]-(genotype:genotype)-[rel:RO:0002200|RO:0002326|RO:0003302!*]->(object:Phenotype)
         WHERE NOT ANY (pheno_rel in rel where pheno_rel.isDefinedBy="https://data.monarchinitiative.org/ttl/mgi.ttl" OR pheno_rel.isDefinedBy="https://data.monarchinitiative.org/ttl/zfin.ttl")
@@ -52,7 +52,7 @@ query: |
         'phenotype' AS object_category,
         'inferred' as qualifier
         UNION ALL
-        MATCH (relation:ObjectProperty{iri:'http://purl.obolibrary.org/obo/RO_0002200'})
+        MATCH (relation:Node{iri:'http://purl.obolibrary.org/obo/RO_0002200'})
         WITH relation
         MATCH path=(subject:gene)<-[:GENO:0000418!*0..1]-(feature)<-[:BFO:0000051!*]-(genotype:genotype)<-[:GENO:0000222|RO:0001000*1..2]-(person)-[rel:RO:0002200|RO:0002326!*]->(object:Phenotype)
         WHERE NOT ANY (pheno_rel in rel where pheno_rel.isDefinedBy="https://data.monarchinitiative.org/ttl/udp.ttl")

--- a/src/main/cypher/golr-loader/genotype-disease.yaml
+++ b/src/main/cypher/golr-loader/genotype-disease.yaml
@@ -1,7 +1,7 @@
 query: |
-        MATCH path=(object:disease)<-[r:RO:0002200|RO:0002610|RO:0002326!]-(person)-[:GENO:0000222|RO:0001000*0..2]->(subject:genotype)
+        MATCH path=(object:disease)<-[relation:RO:0002200|RO:0002610|RO:0002326!]-(person)-[:GENO:0000222|RO:0001000*0..2]->(subject:genotype)
         RETURN path,
-        subject, object, r as relation,
+        subject, object, relation,
         'genotype' AS subject_category,
         'disease' AS object_category,
         'direct' AS qualifier

--- a/src/main/cypher/golr-loader/literature-disease.yaml
+++ b/src/main/cypher/golr-loader/literature-disease.yaml
@@ -1,30 +1,30 @@
 query: |
-        MATCH path=(pub:publication)<-[:dc:source]-(association)-[r:OBAN:association_has_object|OBAN:association_has_subject]->(disease:disease)
-        RETURN path,
+        MATCH path=(pub:publication)<-[relation:dc:source]-(association)-[r:OBAN:association_has_object|OBAN:association_has_subject]->(disease:disease)
+        RETURN path, relation,
             pub as subject,
             disease as object,
             'publication' as subject_category,
             'disease' as object_category,
             'direct' as qualifier
         UNION ALL
-        MATCH path=(pub:publication)-[r:IAO:0000142|IAO:0000136]->(disease:disease)
-        RETURN path,
+        MATCH path=(pub:publication)-[relation:IAO:0000142|IAO:0000136]->(disease:disease)
+        RETURN path, relation,
             pub as subject,
             disease as object,
             'publication' as subject_category,
             'disease' as object_category,
             'direct' as qualifier
         UNION ALL
-        MATCH path=(pub:publication)-[r:IAO:0000142|IAO:0000136]->(model)-[:RO:0003301]->(disease:disease)
-        RETURN path,
+        MATCH path=(pub:publication)-[relation:IAO:0000142|IAO:0000136]->(model)-[:RO:0003301]->(disease:disease)
+        RETURN path, relation,
             pub as subject,
             disease as object,
             'publication' as subject_category,
             'disease' as object_category,
             'indirect' as qualifier
         UNION ALL
-        MATCH path=(pub:publication)<-[:dc:source]-(association)-[r:OBAN:association_has_object|OBAN:association_has_subject]->(model)-[:RO:0003301]->(disease:disease)
-        RETURN path,
+        MATCH path=(pub:publication)<-[relation:dc:source]-(association)-[r:OBAN:association_has_object|OBAN:association_has_subject]->(model)-[:RO:0003301]->(disease:disease)
+        RETURN path, relation,
             pub as subject,
             disease as object,
             'publication' as subject_category,

--- a/src/main/cypher/golr-loader/literature-gene.yaml
+++ b/src/main/cypher/golr-loader/literature-gene.yaml
@@ -1,65 +1,65 @@
 query: |
-        MATCH path=(pub:publication)-[r:IAO:0000142|IAO:0000136]->(x:gene)
-        RETURN path,
+        MATCH path=(pub:publication)-[relation:IAO:0000142|IAO:0000136]->(x:gene)
+        RETURN path, relation,
             pub as subject,
             x as object,
             'publication' as subject_category,
             'gene' as object_category,
             'direct' as qualifier
         UNION ALL
-        MATCH path=(pub:publication)<-[:dc:source]-(association)-[r:OBAN:association_has_subject|OBAN:association_has_object]->(gene:gene)
-        RETURN path,
+        MATCH path=(pub:publication)<-[relation:dc:source]-(association)-[r:OBAN:association_has_subject|OBAN:association_has_object]->(gene:gene)
+        RETURN path, relation,
             pub as subject,
             gene as object,
             'publication' as subject_category,
             'gene' as object_category,
             'direct' as qualifier
         UNION ALL
-        MATCH path=(pub:publication)<-[:dc:source]-(association)-[r:OBAN:association_has_object|OBAN:association_has_subject]->(genotype:genotype)-[:BFO:0000051!*]->(variant)-[:GENO:0000418!*0..1]->(gene:gene)
+        MATCH path=(pub:publication)<-[relation:dc:source]-(association)-[r:OBAN:association_has_object|OBAN:association_has_subject]->(genotype:genotype)-[:BFO:0000051!*]->(variant)-[:GENO:0000418!*0..1]->(gene:gene)
         WHERE ((variant:`sequence feature` AND NOT variant:gene) OR variant:`variant locus`) OR variant:`reagent targeted gene`
-        RETURN path,
+        RETURN path, relation,
             pub as subject,
             gene as object,
             'publication' as subject_category,
             'gene' as object_category,
             'indirect' as qualifier
         UNION ALL
-        MATCH path=(pub:publication)-[r:IAO:0000142|IAO:0000136]->(genotype:genotype)-[:BFO:0000051!*]->(variant)-[:GENO:0000418!*0..1]->(gene:gene)
-        RETURN path,
+        MATCH path=(pub:publication)-[relation:IAO:0000142|IAO:0000136]->(genotype:genotype)-[:BFO:0000051!*]->(variant)-[:GENO:0000418!*0..1]->(gene:gene)
+        RETURN path, relation,
             pub as subject,
             gene as object,
             'publication' as subject_category,
             'gene' as object_category,
             'inferred' as qualifier
         UNION ALL
-        MATCH path=(pub:publication)<-[:dc:source]-(association)-[r:OBAN:association_has_subject|OBAN:association_has_object]->(variant)-[:GENO:0000418!*0..1]->(gene:gene)
+        MATCH path=(pub:publication)<-[relation:dc:source]-(association)-[r:OBAN:association_has_subject|OBAN:association_has_object]->(variant)-[:GENO:0000418!*0..1]->(gene:gene)
         WHERE ((variant:`sequence feature` AND NOT variant:gene) OR variant:`variant locus`) OR variant:`reagent targeted gene`
-        RETURN path,
+        RETURN path, relation,
             pub as subject,
             gene as object,
             'publication' as subject_category,
             'gene' as object_category,
             'direct' as qualifier
         UNION ALL
-        MATCH path=(pub:publication)-[r:IAO:0000142|IAO:0000136]->(variant)-[:GENO:0000418!*0..1]->(gene:gene)
-        RETURN path,
+        MATCH path=(pub:publication)-[relation:IAO:0000142|IAO:0000136]->(variant)-[:GENO:0000418!*0..1]->(gene:gene)
+        RETURN path, relation,
             pub as subject,
             gene as object,
             'publication' as subject_category,
             'gene' as object_category,
             'inferred' as qualifier
         UNION ALL
-        MATCH path=(pub:publication)<-[:dc:source]-(association)-[r:OBAN:association_has_subject|OBAN:association_has_object]->(person)-[:GENO:0000222]->(genotype:genotype)-[:BFO:0000051!*]->(variant)-[:GENO:0000418!*0..1]->(gene:gene)
+        MATCH path=(pub:publication)<-[relation:dc:source]-(association)-[r:OBAN:association_has_subject|OBAN:association_has_object]->(person)-[:GENO:0000222]->(genotype:genotype)-[:BFO:0000051!*]->(variant)-[:GENO:0000418!*0..1]->(gene:gene)
         WHERE ((variant:`sequence feature` AND NOT variant:gene) OR variant:`variant locus`) OR variant:`reagent targeted gene`
-        RETURN path,
+        RETURN path, relation,
             pub as subject,
             gene as object,
             'publication' as subject_category,
             'gene' as object_category,
             'indirect' as qualifier
         UNION ALL
-        MATCH path=(pub:publication)-[r:IAO:0000142|IAO:0000136]->(person)-[:GENO:0000222]->(genotype:genotype)-[:BFO:0000051!*]->(variant)-[:GENO:0000418!*0..1]->(gene:gene)
-        RETURN path,
+        MATCH path=(pub:publication)-[relation:IAO:0000142|IAO:0000136]->(person)-[:GENO:0000222]->(genotype:genotype)-[:BFO:0000051!*]->(variant)-[:GENO:0000418!*0..1]->(gene:gene)
+        RETURN path, relation,
             pub as subject,
             gene as object,
             'publication' as subject_category,

--- a/src/main/cypher/golr-loader/literature-genotype.yaml
+++ b/src/main/cypher/golr-loader/literature-genotype.yaml
@@ -1,30 +1,30 @@
 query: |
-        MATCH path=(pub:publication)<-[:dc:source]-(association)-[r:OBAN:association_has_object|OBAN:association_has_subject]->(genotype:genotype)
-        RETURN path,
+        MATCH path=(pub:publication)<-[relation:dc:source]-(association)-[r:OBAN:association_has_object|OBAN:association_has_subject]->(genotype:genotype)
+        RETURN path, relation,
             pub as subject,
             genotype as object,
             'publication' as subject_category,
             'genotype' as object_category,
             'direct' as qualifier
         UNION ALL
-        MATCH path=(pub:publication)-[r:IAO:0000142|IAO:0000136]->(genotype:genotype)
-        RETURN path,
+        MATCH path=(pub:publication)-[relation:IAO:0000142|IAO:0000136]->(genotype:genotype)
+        RETURN path, relation,
             pub as subject,
             genotype as object,
             'publication' as subject_category,
             'genotype' as object_category,
             'direct' as qualifier
         UNION ALL
-        MATCH path=(pub:publication)<-[:dc:source]-(association)-[r:OBAN:association_has_object|OBAN:association_has_subject]->(person)-[:GENO:0000222|RO:0001000*1..2]->(genotype:genotype)
-        RETURN path,
+        MATCH path=(pub:publication)<-[relation:dc:source]-(association)-[r:OBAN:association_has_object|OBAN:association_has_subject]->(person)-[:GENO:0000222|RO:0001000*1..2]->(genotype:genotype)
+        RETURN path, relation,
             pub as subject,
             genotype as object,
             'publication' as subject_category,
             'genotype' as object_category,
             'indirect' as qualifier
         UNION ALL
-        MATCH path=(pub:publication)-[r:IAO:0000142|IAO:0000136]->(person)-[:GENO:0000222|RO:0001000*1..2]->(genotype:genotype)
-        RETURN path,
+        MATCH path=(pub:publication)-[relation:IAO:0000142|IAO:0000136]->(person)-[:GENO:0000222|RO:0001000*1..2]->(genotype:genotype)
+        RETURN path, relation,
             pub as subject,
             genotype as object,
             'publication' as subject_category,

--- a/src/main/cypher/golr-loader/literature-model.yaml
+++ b/src/main/cypher/golr-loader/literature-model.yaml
@@ -1,15 +1,15 @@
 query: |
-        MATCH path=(pub:publication)-[r:IAO:0000142|IAO:0000136]->(model)-[:RO:0003301]->()
+        MATCH path=(pub:publication)-[relation:IAO:0000142|IAO:0000136]->(model)-[:RO:0003301]->()
         RETURN path,
-            pub as subject,
+            pub as subject, relation,
             model as object,
             'publication' as subject_category,
             'model' as object_category,
             'direct' as qualifier 
         UNION ALL
-        MATCH path=(pub:publication)<-[:dc:source]-(association)-[r:OBAN:association_has_object|OBAN:association_has_subject]->(model)-[:RO:0003301]->()
+        MATCH path=(pub:publication)<-[relation:dc:source]-(association)-[r:OBAN:association_has_object|OBAN:association_has_subject]->(model)-[:RO:0003301]->()
         RETURN path,
-            pub as subject,
+            pub as subject, relation,
             model as object,
             'publication' as subject_category,
             'model' as object_category,

--- a/src/main/cypher/golr-loader/literature-phenotype.yaml
+++ b/src/main/cypher/golr-loader/literature-phenotype.yaml
@@ -1,15 +1,15 @@
 query: |
-        MATCH path=(pub:publication)<-[:dc:source]-(association)-[r:OBAN:association_has_object|OBAN:association_has_subject]->(phenotype:Phenotype)
+        MATCH path=(pub:publication)<-[relation:dc:source]-(association)-[r:OBAN:association_has_object|OBAN:association_has_subject]->(phenotype:Phenotype)
         RETURN path,
-            pub as subject,
+            pub as subject, relation,
             phenotype as object,
             'publication' as subject_category,
             'phenotype' as object_category,
             'direct' as qualifier
         UNION ALL
-        MATCH path=(pub:publication)-[r:IAO:0000142|IAO:0000136]->(phenotype:Phenotype)
+        MATCH path=(pub:publication)-[relation:IAO:0000142|IAO:0000136]->(phenotype:Phenotype)
         RETURN path,
-            pub as subject,
+            pub as subject, relation,
             phenotype as object,
             'publication' as subject_category,
             'phenotype' as object_category,

--- a/src/main/cypher/golr-loader/literature-variant.yaml
+++ b/src/main/cypher/golr-loader/literature-variant.yaml
@@ -1,51 +1,51 @@
 query: |
-        MATCH path=(pub:publication)<-[:dc:source]-(association)-[r:OBAN:association_has_object|OBAN:association_has_subject]->(genotype:genotype)-[:BFO:0000051!*]->(variant)
+        MATCH path=(pub:publication)<-[relation:dc:source]-(association)-[r:OBAN:association_has_object|OBAN:association_has_subject]->(genotype:genotype)-[:BFO:0000051!*]->(variant)
         WHERE (((variant:`sequence feature` AND NOT variant:gene) OR variant:`variant locus`) AND NOT variant:anonymous) OR variant:`reagent targeted gene`
         RETURN path,
-            pub as subject,
+            pub as subject, relation,
             variant as object,
             'publication' as subject_category,
             'variant' as object_category,
             'indirect' as qualifier
         UNION ALL
-        MATCH path=(pub:publication)-[r:IAO:0000142|IAO:0000136]->(genotype:genotype)-[:BFO:0000051!*]->(variant)
+        MATCH path=(pub:publication)-[relation:IAO:0000142|IAO:0000136]->(genotype:genotype)-[:BFO:0000051!*]->(variant)
         WHERE (((variant:`sequence feature` AND NOT variant:gene) OR variant:`variant locus`) AND NOT variant:anonymous) OR variant:`reagent targeted gene`
         RETURN path,
-            pub as subject,
+            pub as subject, relation,
             variant as object,
             'publication' as subject_category,
             'variant' as object_category,
             'inferred' as qualifier
         UNION ALL
-        MATCH path=(pub:publication)<-[:dc:source]-(association)-[r:OBAN:association_has_subject|OBAN:association_has_object]->(variant)
+        MATCH path=(pub:publication)<-[relation:dc:source]-(association)-[r:OBAN:association_has_subject|OBAN:association_has_object]->(variant)
         WHERE (((variant:`sequence feature` AND NOT variant:gene) OR variant:`variant locus`) AND NOT variant:anonymous) OR variant:`reagent targeted gene`
         RETURN path,
-            pub as subject,
+            pub as subject, relation,
             variant as object,
             'publication' as subject_category,
             'variant' as object_category,
             'direct' as qualifier
         UNION ALL
-        MATCH path=(pub:publication)-[r:IAO:0000142|IAO:0000136]->(variant)
+        MATCH path=(pub:publication)-[relation:IAO:0000142|IAO:0000136]->(variant)
         RETURN path,
-            pub as subject,
+            pub as subject, relation,
             variant as object,
             'publication' as subject_category,
             'variant' as object_category,
             'inferred' as qualifier
         UNION ALL
-        MATCH path=(pub:publication)<-[:dc:source]-(association)-[r:OBAN:association_has_subject|OBAN:association_has_object]->(person)-[:GENO:0000222|RO:0001000*1..2]->(genotype:genotype)-[:BFO:0000051!*]->(variant)
+        MATCH path=(pub:publication)<-[relation:dc:source]-(association)-[r:OBAN:association_has_subject|OBAN:association_has_object]->(person)-[:GENO:0000222|RO:0001000*1..2]->(genotype:genotype)-[:BFO:0000051!*]->(variant)
         WHERE (((variant:`sequence feature` AND NOT variant:gene) OR variant:`variant locus`) AND NOT variant:anonymous) OR variant:`reagent targeted gene`
         RETURN path,
-            pub as subject,
+            pub as subject, relation,
             variant as object,
             'publication' as subject_category,
             'variant' as object_category,
             'indirect' as qualifier
         UNION ALL
-        MATCH path=(pub:publication)-[r:IAO:0000142|IAO:0000136]->(person)-[:GENO:0000222|RO:0001000*1..2]->(genotype:genotype)-[:BFO:0000051!*]->(variant)
+        MATCH path=(pub:publication)-[relation:IAO:0000142|IAO:0000136]->(person)-[:GENO:0000222|RO:0001000*1..2]->(genotype:genotype)-[:BFO:0000051!*]->(variant)
         RETURN path,
-            pub as subject,
+            pub as subject, relation,
             variant as object,
             'publication' as subject_category,
             'variant' as object_category,

--- a/src/main/cypher/golr-loader/model-case.yaml
+++ b/src/main/cypher/golr-loader/model-case.yaml
@@ -1,7 +1,7 @@
 query: |
-        MATCH path=(subject)-[:RO:0001000]->(object:case)
+        MATCH path=(subject)-[relation:RO:0001000]->(object:case)
         RETURN path,
-        subject, object,
+        subject, object, relation,
         'model' AS subject_category,
         'case' AS object_category,
         'direct' AS qualifier

--- a/src/main/cypher/golr-loader/model-family.yaml
+++ b/src/main/cypher/golr-loader/model-family.yaml
@@ -1,7 +1,6 @@
 query: |
-        START pco = node:node_auto_index(iri="https://purl.obolibrary.org/obo/PCO_0000020")
-        MATCH path=(subject)-[:RO:0001000]->(person)-[:RO:0002350]->(object)-[:type]->(pco)
-        RETURN path,
+        MATCH path=(subject)-[:RO:0001000]->(person)-[relation:RO:0002350]->(object)-[:type]->(pco:Node{iri='https://purl.obolibrary.org/obo/PCO_0000020'})
+        RETURN path, relation,
         subject, object,
         'model' AS subject_category,
         'family' AS object_category,

--- a/src/main/cypher/golr-loader/model-family.yaml
+++ b/src/main/cypher/golr-loader/model-family.yaml
@@ -1,5 +1,5 @@
 query: |
-        MATCH path=(subject)-[:RO:0001000]->(person)-[relation:RO:0002350]->(object)-[:type]->(pco:Node{iri='https://purl.obolibrary.org/obo/PCO_0000020'})
+        MATCH path=(subject)-[:RO:0001000]->(person)-[relation:RO:0002350]->(object)-[:type]->(pco:Node{iri:'https://purl.obolibrary.org/obo/PCO_0000020'})
         RETURN path, relation,
         subject, object,
         'model' AS subject_category,

--- a/src/main/cypher/golr-loader/model-gene.yaml
+++ b/src/main/cypher/golr-loader/model-gene.yaml
@@ -1,9 +1,9 @@
 query: |
         MATCH path=(subject)-[:RO:0001000|GENO:0000222*1..2]->(genotype:genotype)-[:BFO:0000051!*]->(variant)-[rel:GENO:0000418|GENO:0000639!*0..1]->(object:gene)
-        WHERE NOT ANY (relation in rel where relation.isDefinedBy="https://data.monarchinitiative.org/ttl/udp.ttl")
+        WHERE NOT ANY (geno_rel in rel where geno_rel.isDefinedBy="https://data.monarchinitiative.org/ttl/udp.ttl")
         AND ((variant:`sequence feature` AND NOT variant:gene) OR variant:`variant locus`) OR variant:`reagent targeted gene`
         RETURN path,
         subject, object,
         'model' AS subject_category,
         'gene' AS object_category,
-        'indirect' AS qualifier
+        'inferred through genotype' AS qualifier

--- a/src/main/cypher/golr-loader/model-genotype.yaml
+++ b/src/main/cypher/golr-loader/model-genotype.yaml
@@ -6,9 +6,9 @@ query: |
         'genotype' AS object_category,
         'direct' AS qualifier
         UNION ALL
-        MATCH path=()<-[:RO:0003301]-(subject)-[:RO:0001000]->(organism)-[:GENO:0000222]->(object:genotype)
+        MATCH path=()<-[:RO:0003301]-(subject)-[:RO:0001000]->(organism)-[relation:GENO:0000222]->(object:genotype)
         RETURN path,
-        subject, object, NULL as relation,
+        subject, object, relation,
         'model' AS subject_category,
         'genotype' AS object_category,
-        'indirect' AS qualifier
+        'direct' AS qualifier

--- a/src/main/cypher/golr-loader/model-variant.yaml
+++ b/src/main/cypher/golr-loader/model-variant.yaml
@@ -1,8 +1,9 @@
 query: |
         MATCH path=(subject)-[rel:RO:0001000|GENO:0000222*1..2]->(genotype:genotype)-[:BFO:0000051!*]->(object)
-        WHERE NOT ANY (relation in rel where relation.isDefinedBy="https://data.monarchinitiative.org/ttl/udp.ttl")
+        MATCH (relation:ObjectProperty{iri:'http://purl.obolibrary.org/obo/GENO_0000222'})
+        WHERE NOT ANY (geno_rel in rel where geno_rel.isDefinedBy="https://data.monarchinitiative.org/ttl/udp.ttl")
         AND (((object:`sequence feature` AND NOT object:gene) OR object:`variant locus`) AND NOT object:anonymous) OR object:`reagent targeted gene`
-        RETURN path,
+        RETURN path, relation,
         subject, object,
         'model' AS subject_category,
         'variant' AS object_category,

--- a/src/main/cypher/golr-loader/model-variant.yaml
+++ b/src/main/cypher/golr-loader/model-variant.yaml
@@ -1,6 +1,7 @@
 query: |
-        MATCH path=(subject)-[rel:RO:0001000|GENO:0000222*1..2]->(genotype:genotype)-[:BFO:0000051!*]->(object)
         MATCH (relation:ObjectProperty{iri:'http://purl.obolibrary.org/obo/GENO_0000222'})
+        WITH relation
+        MATCH path=(subject)-[rel:RO:0001000|GENO:0000222*1..2]->(genotype:genotype)-[:BFO:0000051!*]->(object)
         WHERE NOT ANY (geno_rel in rel where geno_rel.isDefinedBy="https://data.monarchinitiative.org/ttl/udp.ttl")
         AND (((object:`sequence feature` AND NOT object:gene) OR object:`variant locus`) AND NOT object:anonymous) OR object:`reagent targeted gene`
         RETURN path, relation,

--- a/src/main/cypher/golr-loader/model-variant.yaml
+++ b/src/main/cypher/golr-loader/model-variant.yaml
@@ -1,5 +1,5 @@
 query: |
-        MATCH (relation:ObjectProperty{iri:'http://purl.obolibrary.org/obo/GENO_0000222'})
+        MATCH (relation:Node{iri:'http://purl.obolibrary.org/obo/GENO_0000222'})
         WITH relation
         MATCH path=(subject)-[rel:RO:0001000|GENO:0000222*1..2]->(genotype:genotype)-[:BFO:0000051!*]->(object)
         WHERE NOT ANY (geno_rel in rel where geno_rel.isDefinedBy="https://data.monarchinitiative.org/ttl/udp.ttl")

--- a/src/main/cypher/golr-loader/pathway-phenotype.yaml
+++ b/src/main/cypher/golr-loader/pathway-phenotype.yaml
@@ -7,7 +7,7 @@ query: |
         r as relation,
         'pathway' as subject_category,
         'phenotype' as object_category,
-        'inferred' as qualifier
+        'inferred through joining gene pathway, gene disease, and homology associations' as qualifier
         UNION ALL
         MATCH path=(pathway:pathway)<-[:RO:0002331]-()<-[:RO:0002205*0..1]-(:gene)-[:RO:HOM0000017!*0..1]-(gene:gene)<-[:GENO:0000418!]-(variant)<-[:BFO:0000051!*]-(genotype:genotype)-[r:RO:0002200|RO:0002610|RO:0002326!*2..]->(phenotype:Phenotype)
         WHERE (((variant:`sequence feature` AND NOT variant:gene) OR variant:`variant locus`) AND NOT variant:anonymous) OR variant:`reagent targeted gene`
@@ -17,7 +17,7 @@ query: |
         r as relation,
         'pathway' as subject_category,
         'phenotype' as object_category,
-        'inferred' as qualifier
+        'inferred through joining gene pathway, gene disease, and homology associations' as qualifier
         UNION ALL
         MATCH path=(pathway:pathway)<-[:RO:0002331]-()<-[:RO:0002205*0..1]-(:gene)-[:RO:HOM0000017!*0..1]-(gene:gene)<-[:GENO:0000418!]-(variant)<-[:BFO:0000051!*]-(genotype:genotype)<-[:GENO:0000222|RO:0001000*1..2]-(person)-[r:RO:0002200|RO:0002610|RO:0002326!*2..]->(phenotype:Phenotype)
         WHERE (((variant:`sequence feature` AND NOT variant:gene) OR variant:`variant locus`) AND NOT variant:anonymous) OR variant:`reagent targeted gene`
@@ -27,4 +27,4 @@ query: |
         r as relation,
         'pathway' as subject_category,
         'phenotype' as object_category,
-        'inferred' as qualifier
+        'inferred through joining gene pathway, gene disease, and homology associations' as qualifier

--- a/src/main/cypher/golr-loader/variant-disease.yaml
+++ b/src/main/cypher/golr-loader/variant-disease.yaml
@@ -7,18 +7,18 @@ query: |
         'disease' AS object_category,
         'direct' as qualifier
         UNION ALL
-        MATCH path=(subject)<-[:BFO:0000051!*]-(genotype:genotype)-[:RO:0002200|RO:0002610|RO:0002326|RO:0003302!]->(object:disease)
+        MATCH path=(subject)<-[:BFO:0000051!*]-(genotype:genotype)-[relation:RO:0002200|RO:0002610|RO:0002326|RO:0003302!]->(object:disease)
         WHERE (((subject:`sequence feature` AND NOT subject:gene) OR subject:`variant locus`) AND NOT subject:anonymous) OR subject:`reagent targeted gene`
         RETURN path,
-        subject, object, NULL as relation,
+        subject, object, relation,
         'variant' AS subject_category,
         'disease' AS object_category,
         'inferred' as qualifier
         UNION ALL
-        MATCH path=(subject)<-[:BFO:0000051!*]-(genotype:genotype)<-[:RO:0001000|GENO:0000222*1..2]-(organism)-[:RO:0002200|RO:0002610|RO:0002326!]->(object:disease)
+        MATCH path=(subject)<-[:BFO:0000051!*]-(genotype:genotype)<-[:RO:0001000|GENO:0000222*1..2]-(organism)-[relation:RO:0002200|RO:0002610|RO:0002326!]->(object:disease)
         WHERE (((subject:`sequence feature` AND NOT subject:gene) OR subject:`variant locus`) AND NOT subject:anonymous) OR subject:`reagent targeted gene`
         RETURN path,
-        subject, object, NULL as relation,
+        subject, object, relation,
         'variant' AS subject_category,
         'disease' AS object_category,
         'inferred' as qualifier

--- a/src/main/cypher/golr-loader/variant-phenotype.yaml
+++ b/src/main/cypher/golr-loader/variant-phenotype.yaml
@@ -7,8 +7,9 @@ query: |
         'phenotype' AS object_category,
         'direct' as qualifier
         UNION ALL
-        MATCH path=(subject)-[:RO:0002200|RO:0002610|RO:0002326|RO:0003302!*2..2]->(object:Phenotype)
         MATCH (relation:ObjectProperty{iri:'http://purl.obolibrary.org/obo/RO_0002200'})
+        WITH relation
+        MATCH path=(subject)-[:RO:0002200|RO:0002610|RO:0002326|RO:0003302!*2..2]->(object:Phenotype)
         WHERE (((subject:`sequence feature` AND NOT subject:gene) OR subject:`variant locus`) AND NOT subject:anonymous) OR subject:`reagent targeted gene`
         RETURN path,
         subject, object, relation,

--- a/src/main/cypher/golr-loader/variant-phenotype.yaml
+++ b/src/main/cypher/golr-loader/variant-phenotype.yaml
@@ -7,7 +7,7 @@ query: |
         'phenotype' AS object_category,
         'direct' as qualifier
         UNION ALL
-        MATCH (relation:ObjectProperty{iri:'http://purl.obolibrary.org/obo/RO_0002200'})
+        MATCH (relation:Node{iri:'http://purl.obolibrary.org/obo/RO_0002200'})
         WITH relation
         MATCH path=(subject)-[:RO:0002200|RO:0002610|RO:0002326|RO:0003302!*2..2]->(object:Phenotype)
         WHERE (((subject:`sequence feature` AND NOT subject:gene) OR subject:`variant locus`) AND NOT subject:anonymous) OR subject:`reagent targeted gene`

--- a/src/main/cypher/golr-loader/variant-phenotype.yaml
+++ b/src/main/cypher/golr-loader/variant-phenotype.yaml
@@ -8,26 +8,27 @@ query: |
         'direct' as qualifier
         UNION ALL
         MATCH path=(subject)-[:RO:0002200|RO:0002610|RO:0002326|RO:0003302!*2..2]->(object:Phenotype)
+        MATCH (relation:ObjectProperty{iri:'http://purl.obolibrary.org/obo/RO_0002200'})
         WHERE (((subject:`sequence feature` AND NOT subject:gene) OR subject:`variant locus`) AND NOT subject:anonymous) OR subject:`reagent targeted gene`
         RETURN path,
-        subject, object, NULL as relation,
+        subject, object, relation,
         'variant' AS subject_category,
         'phenotype' AS object_category,
-        'inferred' as qualifier
+        'inferred through disease' as qualifier
         UNION ALL
-        MATCH path=(subject)<-[:BFO:0000051!*]-(genotype)-[:RO:0002200|RO:0002610|RO:0002326|RO:0003302!]->(object:Phenotype)
+        MATCH path=(subject)<-[:BFO:0000051!*]-(genotype)-[relation:RO:0002200|RO:0002610|RO:0002326|RO:0003302!]->(object:Phenotype)
         WHERE (((subject:`sequence feature` AND NOT subject:gene) OR subject:`variant locus`) AND NOT subject:anonymous) OR subject:`reagent targeted gene`
         RETURN path,
-        subject, object, NULL as relation,
+        subject, object, relation,
         'variant' AS subject_category,
         'phenotype' AS object_category,
-        'inferred' as qualifier
+        'inferred through genotype' as qualifier
         UNION ALL
-        MATCH path=(subject)<-[:BFO:0000051!*]-(genotype)<-[:RO:0001000|GENO:0000222*1..2]-(organism)-[rel:RO:0002200|RO:0002610|RO:0002326!]->(object:Phenotype)
-        WHERE NOT rel.isDefinedBy="https://data.monarchinitiative.org/ttl/udp.ttl"
+        MATCH path=(subject)<-[:BFO:0000051!*]-(genotype)<-[:RO:0001000|GENO:0000222*1..2]-(organism)-[relation:RO:0002200|RO:0002610|RO:0002326!]->(object:Phenotype)
+        WHERE NOT relation.isDefinedBy="https://data.monarchinitiative.org/ttl/udp.ttl"
         AND (((subject:`sequence feature` AND NOT subject:gene) OR subject:`variant locus`) AND NOT subject:anonymous) OR subject:`reagent targeted gene`
         RETURN path,
-        subject, object, NULL as relation,
+        subject, object, relation,
         'variant' AS subject_category,
         'phenotype' AS object_category,
-        'inferred' as qualifier
+        'inferred through model' as qualifier


### PR DESCRIPTION
Adds relation to return statement when possible.

In a small subset of paths, pick a representative property, for example, 'has phenotype' for gene to phenotype associations inferred across a disease, or 'has genotype' for model/case to variant associations.

One exception is for model-gene and case-gene relationships as I could not find an appropriate relation. We need something like 'has gene of interest.'

See https://github.com/monarch-initiative/monarch-cypher-queries/issues/7