### PR TITLE
Filter out infrequent phenotypes for human G2P

### DIFF
--- a/src/main/cypher/golr-loader/gene-phenotype.yaml
+++ b/src/main/cypher/golr-loader/gene-phenotype.yaml
@@ -26,12 +26,11 @@ query: |
         'phenotype' AS object_category,
         'direct' as qualifier
         UNION ALL
-        MATCH path=(subject:gene)<-[:GENO:0000418!*0..1]-(feature)-[:RO:0002200|GENO:0000840]->(disease:disease)-[relation:RO:0002200]->(object:phenotype)
-        OPTIONAL MATCH (assoc:association)-[:OBAN:association_has_subject]->(disease),
-               (assoc)-[:OBAN:association_has_object]->(object),
-               (assoc)-[:OBAN:association_has_predicate]->(has_pheno:Node{iri:'http://purl.obolibrary.org/obo/RO_0002200'}),
-               (assoc)-[::frequencyOfPhenotype]->(frequency)
-        WHERE NOT frequency.iri = 'http://purl.obolibrary.org/obo/HP_0040284'
+        MATCH path=(subject:gene)<-[:GENO:0000418!*0..1]-(feature)-[:RO:0002200|GENO:0000840]->(disease)-[relation:RO:0002200]->(object:phenotype)
+        MATCH (assoc:association)-[:OBAN:association_has_subject]->(disease),
+              (assoc)-[:OBAN:association_has_object]->(object),
+              (assoc)-[:OBAN:association_has_predicate]->(has_pheno:Node{iri:'http://purl.obolibrary.org/obo/RO_0002200'})
+        WHERE NOT (assoc)-[::frequencyOfPhenotype]->(:Node{iri:'http://purl.obolibrary.org/obo/HP_0040284'})
         RETURN path,
         subject, object, relation,
         'gene' AS subject_category,

--- a/src/main/cypher/golr-loader/gene-phenotype.yaml
+++ b/src/main/cypher/golr-loader/gene-phenotype.yaml
@@ -26,9 +26,12 @@ query: |
         'phenotype' AS object_category,
         'direct' as qualifier
         UNION ALL
-        MATCH (relation:Node{iri:'http://purl.obolibrary.org/obo/RO_0002200'})
-        WITH relation
-        MATCH path=(subject:gene)<-[:GENO:0000418!*0..1]-(feature)-[:RO:0002200|GENO:0000840!*2..]->(object:phenotype)
+        MATCH path=(subject:gene)<-[:GENO:0000418!*0..1]-(feature)-[:RO:0002200|GENO:0000840]->(disease:disease)-[relation:RO:0002200]->(object:phenotype)
+        OPTIONAL MATCH (assoc:association)-[:OBAN:association_has_subject]->(disease),
+               (assoc)-[:OBAN:association_has_object]->(object),
+               (assoc)-[:OBAN:association_has_predicate]->(has_pheno:Node{iri:'http://purl.obolibrary.org/obo/RO_0002200'}),
+               (assoc)-[::frequencyOfPhenotype]->(frequency)
+        WHERE NOT frequency.iri = 'http://purl.obolibrary.org/obo/HP_0040284'
         RETURN path,
         subject, object, relation,
         'gene' AS subject_category,


### PR DESCRIPTION
When inferring phenotypes via a gene to disease relationship, we may want to filter out phenotypes observed very infrequently (1-4%) for a disease.