### PR TITLE
Replace unions with collect unwind

### DIFF
--- a/src/main/cypher/golr-loader/case-disease.yaml
+++ b/src/main/cypher/golr-loader/case-disease.yaml
@@ -1,17 +1,40 @@
 query: |
         MATCH path=(object:disease)<-[relation:RO:0003301]-(model)-[:RO:0001000]->(subject:case)
-        RETURN path,
-        subject, object, relation,
-        'case_disease' as association_type,
-        'case' AS subject_category,
-        'disease' AS object_category,
-        'direct' AS qualifier
-        UNION ALL
+
+        WITH COLLECT ({
+            path:path,
+            relation:relation,
+            subject:subject,
+            object:object,
+            association_type:'case_disease',
+            subject_category:'case',
+            object_category:'disease',
+            qualifier:'direct'
+        }) as rows
+
         MATCH path=(object:disease)<-[relation:RO:0002200]-(subject:case)
-        RETURN path,
-        subject, object, relation,
-        'case_disease' as association_type,
-        'case' AS subject_category,
-        'disease' AS object_category,
-        'direct' AS qualifier
+
+        WITH rows + COLLECT ({
+            path:path,
+            relation:relation,
+            subject:subject,
+            object:object,
+            association_type:'case_disease',
+            subject_category:'case',
+            object_category:'disease',
+            qualifier:'direct'
+        }) as rows
+
+        UNWIND rows as row
+        RETURN 
+            row.path as path,
+            row.relation as relation,
+            row.subject as subject,
+            row.object as object,
+            row.association_type as association_type,
+            row.subject_category as subject_category,
+            row.object_category as object_category,
+            row.qualifier as qualifier
+        ORDER BY subject, object
+
 subject_closure: "equivalentClass|sameAs|type"

--- a/src/main/cypher/golr-loader/case-gene.yaml
+++ b/src/main/cypher/golr-loader/case-gene.yaml
@@ -1,10 +1,13 @@
 query: |
         MATCH path=(model)-[:RO:0001000*0..1]->(subject:case)-[:GENO:0000222]->(genotype)-[:BFO:0000051!*]->(variant)-[:GENO:0000418|RO:0002566!*0..1]->(object:gene)
-        RETURN path,
-        subject, object,
-        'case_gene' as association_type,
-        'case' AS subject_category,
-        'gene' AS object_category,
-        'indirect' AS qualifier
+        RETURN 
+            path,
+            subject,
+            object,
+            'case_gene' as association_type,
+            'case' AS subject_category,
+            'gene' AS object_category,
+            'indirect' AS qualifier
+        ORDER BY subject, object
 subject_closure: "equivalentClass|sameAs|type"
 object_closure: "equivalentClass|sameAs|type"

--- a/src/main/cypher/golr-loader/case-genotype.yaml
+++ b/src/main/cypher/golr-loader/case-genotype.yaml
@@ -1,10 +1,14 @@
 query: |
         MATCH path=(model)-[:RO:0001000*0..1]->(subject:case)-[relation:GENO:0000222]->(object:genotype)
-        RETURN path,
-        subject, object, relation,
-        'case_genotype' as association_type,
-        'case' AS subject_category,
-        'genotype' AS object_category,
-        'direct' AS qualifier
+        RETURN 
+            path,
+            subject,
+            object,
+            relation,
+            'case_genotype' as association_type,
+            'case' AS subject_category,
+            'genotype' AS object_category,
+            'direct' AS qualifier
+        ORDER BY subject, object
 subject_closure: "equivalentClass|sameAs|type"
 object_closure: "equivalentClass|sameAs|type"

--- a/src/main/cypher/golr-loader/case-phenotype.yaml
+++ b/src/main/cypher/golr-loader/case-phenotype.yaml
@@ -1,9 +1,13 @@
 query: |
         MATCH path=(subject:case)-[relation:RO:0002200]->(object:phenotype)
-        RETURN path,
-        subject, object, relation,
-        'case_phenotype' as association_type,
-        'case' AS subject_category,
-        'phenotype' AS object_category,
-        'direct' AS qualifier
+        RETURN 
+            path,
+            subject,
+            object,
+            relation,
+            'case_phenotype' as association_type,
+            'case' AS subject_category,
+            'phenotype' AS object_category,
+            'direct' AS qualifier
+        ORDER BY subject, object
 subject_closure: "equivalentClass|sameAs|type"

--- a/src/main/cypher/golr-loader/case-variant.yaml
+++ b/src/main/cypher/golr-loader/case-variant.yaml
@@ -1,10 +1,14 @@
 query: |
         MATCH path=(model)-[:RO:0001000*0..1]->(subject:case)-[relation:GENO:0000222]->(genotype:genotype)-[:BFO:0000051!*]->(object:variant)
-        RETURN path,
-        subject, object, relation,
-        'case_variant' as association_type,
-        'case' AS subject_category,
-        'variant' AS object_category,
-        'inferred through intrinsic genotype' AS qualifier
+        RETURN 
+            path,
+            subject,
+            object,
+            relation,
+            'case_variant' as association_type,
+            'case' AS subject_category,
+            'variant' AS object_category,
+            'inferred through intrinsic genotype' AS qualifier
+        ORDER BY subject, object
 subject_closure: "equivalentClass|sameAs|type"
 object_closure: "equivalentClass|sameAs|type"

--- a/src/main/cypher/golr-loader/disease-pathway.yaml
+++ b/src/main/cypher/golr-loader/disease-pathway.yaml
@@ -1,18 +1,41 @@
 query: |
-        MATCH path=(subject:disease)<-[:RO:0002200|RO:0002610|RO:0002326!]-(variant:variant)-[:GENO:0000418!*0..1]->(:gene)-[:RO:0002205*0..1]->()-[relation:RO:0002331]->(object:pathway)
-        RETURN path,
-        subject, object, relation,
-        'disease_pathway' as association_type,
-        'disease' AS subject_category,
-        'pathway' AS object_category,
-        'inferred through joining gene disease and gene pathway associations' AS qualifier
-        UNION ALL
-        MATCH path=(subject:disease)<-[relation:RO:0002418!]-(object:pathway)
-        RETURN path,
-        subject, object, relation,
-        'disease_pathway' as association_type,
-        'disease' AS subject_category,
-        'pathway' AS object_category,
-        'direct' AS qualifier
+        MATCH path=(subject:disease)<-[:RO:0002200|RO:0002610|RO:0002326!]-(variant)-[:GENO:0000418!*0..1]->(:gene)-[:RO:0002205*0..1]->()-[relation:RO:0002331]->(object:pathway)
+
+        WITH COLLECT ({
+            path:path,
+            relation:relation,
+            subject:subject,
+            object:object,
+            association_type:'disease_pathway',
+            subject_category:'disease',
+            object_category:'pathway',
+            qualifier:'inferred by joining gene disease and gene pathway associations'
+        }) as rows
+
+        // This query returns 0 rows
+        // MATCH path=(subject:disease)<-[relation:RO:0002418!]-(object:pathway)
+
+        //WITH rows + COLLECT ({
+        //    path:path,
+        //    relation:relation,
+        //    subject:subject,
+        //    object:object,
+        //    association_type:'disease_pathway',
+        //   subject_category:'disease',
+        //    object_category:'pathway',
+        //    qualifier:'direct'
+        //}) as rows
+
+        UNWIND rows as row
+        RETURN 
+            row.path as path,
+            row.relation as relation,
+            row.subject as subject,
+            row.object as object,
+            row.association_type as association_type,
+            row.subject_category as subject_category,
+            row.object_category as object_category,
+            row.qualifier as qualifier
+        ORDER BY subject, object
 
 

--- a/src/main/cypher/golr-loader/disease-phenotype.yaml
+++ b/src/main/cypher/golr-loader/disease-phenotype.yaml
@@ -9,9 +9,15 @@ query: |
                        (assoc)-[:OBAN:association_has_object]->(object),
                        (assoc)-[:OBAN:association_has_predicate]->(has_pheno:Node{iri:'http://purl.obolibrary.org/obo/RO_0002200'}),
                        (assoc)-[::frequencyOfPhenotype]->(frequency)
-        RETURN path, onset, frequency,
-        subject, object, relation,
-        'disease_phenotype' as association_type,
-        'disease' AS subject_category,
-        'phenotype' AS object_category,
-        'direct' as qualifier
+        RETURN 
+            path,
+            onset, 
+            frequency,
+            subject,
+            object,
+            relation,
+            'disease_phenotype' as association_type,
+            'disease' AS subject_category,
+            'phenotype' AS object_category,
+            'direct' as qualifier
+        ORDER BY subject, object

--- a/src/main/cypher/golr-loader/gene-anatomy.yaml
+++ b/src/main/cypher/golr-loader/gene-anatomy.yaml
@@ -1,10 +1,14 @@
 query: |
         MATCH path=(subject:gene)-[relation:RO:0002206]->(object:`anatomical entity`)
-        RETURN path,
-        subject, object, relation,
-        'gene_anatomy' as association_type,
-        'gene' AS subject_category,
-        'anatomical entity' AS object_category,
-        'direct' AS qualifier
+        RETURN 
+            path,
+            subject,
+            object,
+            relation,
+            'gene_anatomy' as association_type,
+            'gene' AS subject_category,
+            'anatomical entity' AS object_category,
+            'direct' AS qualifier
+        ORDER BY subject, object
 subject_closure: "equivalentClass|sameAs|type"
 object_closure: "subClassOf|BFO:0000050"

--- a/src/main/cypher/golr-loader/gene-disease.yaml
+++ b/src/main/cypher/golr-loader/gene-disease.yaml
@@ -2,20 +2,45 @@ query: |
         MATCH (relation:Node{iri:'http://purl.obolibrary.org/obo/RO_0003303'})
         WITH relation
         MATCH path=(subject:gene)<-[geno:GENO:0000418|GENO:0000641!*0..1]-(feature)-[rel:RO:0002200|RO:0002610|RO:0002326|RO:0003302!]->(object:disease)
-        WHERE (subject)<-[:GENO:0000418|GENO:0000639!*0..1]-()<-[:BFO:0000051!*0..]-()-[:RO:0002200|RO:0003303|GENO:0000840]->(object)        RETURN path,
-            subject, object, relation,
-            'gene_disease' as association_type,
-            'gene' AS subject_category,
-            'disease' AS object_category,
-            'inferred through variant' as qualifier
-        UNION ALL
+        WHERE (subject)<-[:GENO:0000418|GENO:0000639!*0..1]-()<-[:BFO:0000051!*0..]-()-[:RO:0002200|RO:0003303|GENO:0000840]->(object)
+
+        WITH COLLECT ({
+            path:path,
+            relation:relation,
+            subject:subject,
+            object:object,
+            association_type:'gene_disease',
+            subject_category:'gene',
+            object_category:'disease',
+            qualifier:'inferred through variant'
+        }) as rows
+
         MATCH (relation:Node{iri:'http://purl.obolibrary.org/obo/RO_0003303'})
-        WITH relation
+        WITH relation, rows
         MATCH path=(subject:gene)<-[:GENO:0000418|GENO:0000641!]-(variant)<-[:BFO:0000051!*]-(genotype:genotype)-[rel:RO:0002200|RO:0002610|RO:0002326|RO:0003302!]->(object:disease)
-        WHERE (subject)<-[:GENO:0000418|GENO:0000639!*0..1]-()<-[:BFO:0000051!*0..]-()-[:RO:0002200|RO:0003303|GENO:0000840]->(object)        RETURN path,
-            subject, object, relation,
-            'gene_disease' as association_type,
-            'gene' AS subject_category,
-            'disease' AS object_category,
-            'inferred through genotype' as qualifier
+        WHERE (subject)<-[:GENO:0000418|GENO:0000639!*0..1]-()<-[:BFO:0000051!*0..]-()-[:RO:0002200|RO:0003303|GENO:0000840]->(object)
+
+        WITH rows + COLLECT ({
+            path:path,
+            relation:relation,
+            subject:subject,
+            object:object,
+            association_type:'gene_disease',
+            subject_category:'gene',
+            object_category:'disease',
+            qualifier:'inferred through genotype'
+        }) as rows
+
+        UNWIND rows as row
+        RETURN 
+            row.path as path,
+            row.relation as relation,
+            row.subject as subject,
+            row.object as object,
+            row.association_type as association_type,
+            row.subject_category as subject_category,
+            row.object_category as object_category,
+            row.qualifier as qualifier
+        ORDER BY subject, object
+
 subject_closure: "equivalentClass|sameAs|type"

--- a/src/main/cypher/golr-loader/gene-function.yaml
+++ b/src/main/cypher/golr-loader/gene-function.yaml
@@ -1,26 +1,54 @@
 query: |
         MATCH path=(subject:gene)-[relation:RO:0002331]->(object:`biological process`)
-        RETURN path,
-        subject, object, relation,
-        'gene_function' as association_type,
-        'gene' AS subject_category,
-        'biological process' AS object_category,
-        'direct' AS qualifier
-        UNION ALL
+
+        WITH COLLECT ({
+            path:path,
+            relation:relation,
+            subject:subject,
+            object:object,
+            association_type:'gene_function',
+            subject_category:'gene',
+            object_category:'biological process',
+            qualifier:'direct'
+        }) as rows
+
         MATCH path=(subject:gene)-[relation:RO:0002327]->(object:`molecular function`)
-        RETURN path,
-        subject, object, relation,
-        'gene_function' as association_type,
-        'gene' AS subject_category,
-        'biological process' AS object_category,
-        'direct' AS qualifier
-        UNION ALL
+
+        WITH rows + COLLECT ({
+            path:path,
+            relation:relation,
+            subject:subject,
+            object:object,
+            association_type:'gene_function',
+            subject_category:'gene',
+            object_category:'molecular function',
+            qualifier:'direct'
+        }) as rows
+
         MATCH path=(subject:gene)-[relation:BFO:0000050]->(object:`cellular component`)
-        RETURN path,
-        subject, object, relation,
-        'gene_function' as association_type,
-        'gene' AS subject_category,
-        'biological process' AS object_category,
-        'direct' AS qualifier
+
+        WITH rows + COLLECT ({
+            path:path,
+            relation:relation,
+            subject:subject,
+            object:object,
+            association_type:'gene_function',
+            subject_category:'gene',
+            object_category:'cellular component',
+            qualifier:'direct'
+        }) as rows
+
+        UNWIND rows as row
+        RETURN 
+            row.path as path,
+            row.relation as relation,
+            row.subject as subject,
+            row.object as object,
+            row.association_type as association_type,
+            row.subject_category as subject_category,
+            row.object_category as object_category,
+            row.qualifier as qualifier
+        ORDER BY subject, object
+
 subject_closure: "equivalentClass|sameAs|type"
 object_closure: "subClassOf|BFO:0000050"

--- a/src/main/cypher/golr-loader/gene-gene.yaml
+++ b/src/main/cypher/golr-loader/gene-gene.yaml
@@ -1,26 +1,55 @@
 query: |
         MATCH path=(subject:gene)-[relation:RO:0002323!]-(object:gene)
-        RETURN path,
-        subject, object, relation,
-        'gene_temporal' as association_type,
-        'gene' AS subject_category,
-        'gene' AS object_category,
-        'direct' AS qualifier
-        UNION ALL
-        MATCH path=(subject:gene)-[relation:RO:0002501!]-(object:gene)
-        RETURN path,
-        subject, object, relation,
-        'gene_temporal' as association_type,
-        'gene' AS subject_category,
-        'gene' AS object_category,
-        'direct' AS qualifier
-        UNION ALL
-        MATCH path=(subject:gene)-[relation:RO:0002528|RO:0002529!]-(object:gene)
-        RETURN path,
-        subject, object, relation,
-        'gene_temporal' as association_type,
-        'gene' AS subject_category,
-        'gene' AS object_category,
-        'direct' AS qualifier
+
+        WITH COLLECT ({
+            path:path,
+            relation:relation,
+            subject:subject,
+            object:object,
+            association_type:'gene_temporal',
+            subject_category:'gene',
+            object_category:'gene',
+            qualifier:'direct'
+        }) as rows
+
+        // This query returns 0 results
+        // MATCH path=(subject:gene)-[relation:RO:0002501!]-(object:gene)
+
+        // WITH rows + COLLECT ({
+        //    path:path,
+        //    relation:relation,
+        //    subject:subject,
+        //    object:object,
+        //    association_type:'gene_temporal',
+        //    subject_category:'gene',
+        //    object_category:'gene',
+        //    qualifier:'direct'
+        // }) as rows
+
+        // This query returns 0 results 
+        // MATCH path=(subject:gene)-[relation:RO:0002528|RO:0002529!]-(object:gene)
+
+        // WITH rows + COLLECT ({
+        //    path:path,
+        //    relation:relation,
+        //    subject:subject,
+        //    object:object,
+        //    association_type:'gene_temporal',
+        //    subject_category:'gene',
+        //    object_category:'gene',
+        //    qualifier:'direct'
+        // }) as rows
+
+        UNWIND rows as row
+        RETURN 
+            row.path as path,
+            row.relation as relation,
+            row.subject as subject,
+            row.object as object,
+            row.association_type as association_type,
+            row.subject_category as subject_category,
+            row.object_category as object_category,
+            row.qualifier as qualifier
+
 subject_closure: "equivalentClass|sameAs|type"
 object_closure: "equivalentClass|sameAs|type"

--- a/src/main/cypher/golr-loader/gene-homology.yaml
+++ b/src/main/cypher/golr-loader/gene-homology.yaml
@@ -1,10 +1,15 @@
 query: |
         MATCH path=(subject:gene)-[relation:RO:HOM0000001!]-(object:gene)
-        RETURN path,
-        subject, object, relation,
-        'gene_homology' as association_type,
-        'gene' AS subject_category,
-        'gene' AS object_category,
-        'direct' AS qualifier
+        RETURN 
+            path,
+            subject, 
+            object, 
+            relation,
+            'gene_homology' as association_type,
+            'gene' AS subject_category,
+            'gene' AS object_category,
+            'direct' AS qualifier
+        ORDER BY subject, object
+
 subject_closure: "equivalentClass|sameAs|type"
 object_closure: "equivalentClass|sameAs|type"

--- a/src/main/cypher/golr-loader/gene-interactions.yaml
+++ b/src/main/cypher/golr-loader/gene-interactions.yaml
@@ -1,12 +1,8 @@
 query: |
-        MATCH path=(subject:gene)-[:RO:0002205*0..1]->(prot1:protein)-[relation:RO:0002434!]-(prot2:protein)<-[:RO:0002205*0..1]-(object:gene)
-        RETURN path,
-        subject, object, relation,
-        'gene_interaction' as association_type,
-        'gene' AS subject_category,
-        'gene' AS object_category,
-        'direct' AS qualifier
-        UNION ALL
+        
+        // This query returns 0 matches
+        // MATCH path=(subject:gene)-[:RO:0002205*0..1]->(prot1:protein)-[relation:RO:0002434!]-(prot2:protein)<-[:RO:0002205*0..1]-(object:gene)
+
         MATCH path=(subject:gene)-[relation:RO:0002434!]-(object:gene)
         RETURN path,
         subject, object, relation,
@@ -14,6 +10,7 @@ query: |
         'gene' AS subject_category,
         'gene' AS object_category,
         'direct' AS qualifier
+        ORDER BY subject, object
 subject_closure: "equivalentClass|sameAs|type"
 object_closure: "equivalentClass|sameAs|type"
         

--- a/src/main/cypher/golr-loader/gene-pathway.yaml
+++ b/src/main/cypher/golr-loader/gene-pathway.yaml
@@ -1,9 +1,13 @@
 query: |
         MATCH path=(subject:gene)-[:RO:0002205*0..1]->()-[relation:RO:0002331]->(object:pathway)
-        RETURN path,
-        subject, object, relation,
-        'gene_pathway' as association_type,
-        'gene' AS subject_category,
-        'pathway' AS object_category,
-        'direct' AS qualifier
+        RETURN 
+            path,
+            subject,
+            object,
+            relation,
+            'gene_pathway' as association_type,
+            'gene' AS subject_category,
+            'pathway' AS object_category,
+            'direct' AS qualifier
+        ORDER BY subject, object
 subject_closure: "equivalentClass|sameAs|type"

--- a/src/main/cypher/golr-loader/gene-phenotype.yaml
+++ b/src/main/cypher/golr-loader/gene-phenotype.yaml
@@ -1,53 +1,97 @@
 query: |
+        // Gene to phenotype via allele/variant to phenotype
         MATCH path=(subject:gene)<-[geno:GENO:0000418!*0..1]-(feature)-[relation:RO:0002200|RO:0002326|RO:0003302!]->(object:phenotype)
         WHERE NOT ANY (rel in geno where rel.isDefinedBy="https://data.monarchinitiative.org/ttl/mgi.ttl")
         AND NOT ANY (rel in geno where "https://data.monarchinitiative.org/ttl/mgi.ttl" in rel.isDefinedBy)
-        RETURN path,
-        subject, object, relation,
-        'gene_phenotype' as association_type,
-        'gene' AS subject_category,
-        'phenotype' AS object_category,
-        'direct' as qualifier
-        UNION ALL
+
+        WITH COLLECT ({
+            path:path,
+            relation:relation,
+            subject:subject,
+            object:object,
+            association_type:'gene_phenotype',
+            subject_category:'gene',
+            object_category:'phenotype',
+            qualifier:'direct'
+        }) as rows
+
+        // Gene to phenotype via allele/variant to phenotype inferred from disease to phenotype
         MATCH path=(subject:gene)<-[:GENO:0000418!*0..1]-(feature)-[:RO:0002200|GENO:0000840|RO:0003303]->(disease)-[relation:RO:0002200]->(object:phenotype)
         MATCH (assoc:association)-[:OBAN:association_has_subject]->(disease),
               (assoc)-[:OBAN:association_has_object]->(object),
               (assoc)-[:OBAN:association_has_predicate]->(has_pheno:Node{iri:'http://purl.obolibrary.org/obo/RO_0002200'})
         WHERE NOT (assoc)-[::frequencyOfPhenotype]->(:Node{iri:'http://purl.obolibrary.org/obo/HP_0040284'})
-        RETURN path,
-        subject, object, relation,
-        'gene_phenotype' as association_type,
-        'gene' AS subject_category,
-        'phenotype' AS object_category,
-        'inferred through variant' as qualifier
-        UNION ALL
+
+        WITH rows + COLLECT ({
+            path:path,
+            relation:relation,
+            subject:subject,
+            object:object,
+            association_type:'gene_phenotype',
+            subject_category:'gene',
+            object_category:'phenotype',
+            qualifier:'inferred through variant'
+        }) as rows
+
+        // Gene to phenotype inferred from genotype to phenotype
         MATCH (relation:Node{iri:'http://purl.obolibrary.org/obo/RO_0002200'})
-        WITH relation
+        WITH relation, rows
         MATCH path=(subject:gene)<-[:GENO:0000418!*0..1]-(feature)<-[:BFO:0000051!*]-(genotype:genotype)-[rel:RO:0002200|RO:0002326|RO:0003302!*]->(object:phenotype)
         WHERE NOT ANY (pheno_rel in rel where pheno_rel.isDefinedBy="https://data.monarchinitiative.org/ttl/mgi.ttl" OR pheno_rel.isDefinedBy="https://data.monarchinitiative.org/ttl/zfin.ttl")
-        RETURN path,
-        subject, object, relation,
-        'gene_phenotype' as association_type,
-        'gene' AS subject_category,
-        'phenotype' AS object_category,
-        'inferred' as qualifier
-        UNION ALL
-        MATCH path=(subject:gene)<-[:GENO:0000418]-(allele)-[:BFO:0000051!*]->(feature)-[relation:RO:0002200|RO:0002326|RO:0002610|RO:0003302!]->(object:phenotype)
-        RETURN path,
-        subject, object, relation,
-        'gene_phenotype' as association_type,
-        'gene' AS subject_category,
-        'phenotype' AS object_category,
-        'inferred' as qualifier
-        UNION ALL
+
+        WITH rows + COLLECT ({
+            path:path,
+            relation:relation,
+            subject:subject,
+            object:object,
+            association_type:'gene_phenotype',
+            subject_category:'gene',
+            object_category:'phenotype',
+            qualifier:'inferred'
+        }) as rows
+
+        // 06-2019 This query does not return results
+        // Gene to phenotype via allele/variant inferred from genotype to phenotype
+        // MATCH path=(subject:gene)<-[:GENO:0000418]-(allele)-[:BFO:0000051!*]->(feature)-[relation:RO:0002200|RO:0002326|RO:0002610|RO:0003302!]->(object:phenotype)
+        //
+        //WITH rows + COLLECT ({
+        //    path:path,
+        //    relation:relation,
+        //    subject:subject,
+        //    object:object,
+        //    association_type:'gene_phenotype',
+        //    subject_category:'gene',
+        //    object_category:'phenotype',
+        //    qualifier:'inferred'
+        //}) as rows
+
+        // Gene to phenotype via genotype-model-phenotype
         MATCH (relation:Node{iri:'http://purl.obolibrary.org/obo/RO_0002200'})
-        WITH relation
+        WITH relation, rows
         MATCH path=(subject:gene)<-[:GENO:0000418!*0..1]-(feature)<-[:BFO:0000051!*]-(genotype:genotype)<-[:GENO:0000222|RO:0001000*1..2]-(person)-[rel:RO:0002200|RO:0002326!*]->(object:phenotype)
         WHERE NOT ANY (pheno_rel in rel where pheno_rel.isDefinedBy="https://data.monarchinitiative.org/ttl/udp.ttl")
-        RETURN path,
-        subject, object, relation,
-        'gene_phenotype' as association_type,
-        'gene' AS subject_category,
-        'phenotype' AS object_category,
-        'inferred' as qualifier
+
+        WITH rows + COLLECT ({
+            path:path,
+            relation:relation,
+            subject:subject,
+            object:object,
+            association_type:'gene_phenotype',
+            subject_category:'gene',
+            object_category:'phenotype',
+            qualifier:'inferred'
+        }) as rows
+
+        UNWIND rows as row
+        RETURN 
+            row.path as path,
+            row.relation as relation,
+            row.subject as subject,
+            row.object as object,
+            row.association_type as association_type,
+            row.subject_category as subject_category,
+            row.object_category as object_category,
+            row.qualifier as qualifier
+        ORDER BY subject, object
+
 subject_closure: "equivalentClass|sameAs|type"

--- a/src/main/cypher/golr-loader/genotype-disease.yaml
+++ b/src/main/cypher/golr-loader/genotype-disease.yaml
@@ -1,9 +1,13 @@
 query: |
         MATCH path=(object:disease)<-[relation:RO:0002200|RO:0002610|RO:0002326!]-(person)-[:GENO:0000222|RO:0001000*0..2]->(subject:genotype)
-        RETURN path,
-        subject, object, relation,
-        'genotype_disease' as association_type,
-        'genotype' AS subject_category,
-        'disease' AS object_category,
-        'direct' AS qualifier
+        RETURN 
+            path,
+            subject,
+            object,
+            relation,
+            'genotype_disease' as association_type,
+            'genotype' AS subject_category,
+            'disease' AS object_category,
+            'direct' AS qualifier
+        ORDER BY subject, object
 subject_closure: "equivalentClass|sameAs|type"

--- a/src/main/cypher/golr-loader/genotype-gene.yaml
+++ b/src/main/cypher/golr-loader/genotype-gene.yaml
@@ -1,10 +1,13 @@
 query: |
         MATCH path=(subject:genotype)-[:BFO:0000051!*]->(variant:variant)-[:GENO:0000418|GENO:0000639!*0..1]->(object:gene)
-        RETURN path,
-        subject, object,
-        'genotype_gene' as association_type,
-        'genotype' AS subject_category,
-        'gene' AS object_category,
-        'direct' AS qualifier
+        RETURN 
+            path,
+            subject,
+            object,
+            'genotype_gene' as association_type,
+            'genotype' AS subject_category,
+            'gene' AS object_category,
+            'direct' AS qualifier
+        ORDER BY subject, object
 subject_closure: "equivalentClass|sameAs|type"
 object_closure: "equivalentClass|sameAs|type"

--- a/src/main/cypher/golr-loader/genotype-phenotype.yaml
+++ b/src/main/cypher/golr-loader/genotype-phenotype.yaml
@@ -2,27 +2,61 @@
 
 query: |
         MATCH path=(subject:genotype)-[relation:RO:0002200|RO:0002610|RO:0002326|RO:0003302!]->(object:phenotype)
-        RETURN path,
-        subject, object, relation,
-        'genotype_phenotype' as association_type,
-        'genotype' AS subject_category,
-        'phenotype' AS object_category,
-        'direct' as qualifier
-        UNION ALL
-        MATCH path=(subject:genotype)-[:RO:0002200|RO:0002610|RO:0002326|RO:0003302!*2..]->(object:phenotype)
-        RETURN path,
-        subject, object, NULL as relation,
-        'genotype_phenotype' as association_type,
-        'genotype' AS subject_category,
-        'phenotype' AS object_category,
-        'inferred' as qualifier
-        UNION ALL
-        MATCH path=(subject:genotype)<-[:GENO:0000222|RO:0001000*1..2]-(s)-[rel:RO:0002200|RO:0002610|RO:0002326|RO:0003302!*1..2]->(object:phenotype)
-        WHERE NOT ANY (relation in rel where relation.isDefinedBy="https://data.monarchinitiative.org/ttl/udp.ttl")
-        RETURN path,
-        subject, object, NULL as relation,
-        'genotype_phenotype' as association_type,
-        'genotype' AS subject_category,
-        'phenotype' AS object_category,
-        'inferred' as qualifier
+
+        WITH COLLECT ({
+            path:path,
+            relation:relation,
+            subject:subject,
+            object:object,
+            association_type:'genotype_phenotype',
+            subject_category:'genotype',
+            object_category:'phenotype',
+            qualifier:'direct'
+        }) as rows
+
+        // Query returns 0 rows
+        //MATCH (relation:Node{iri:'http://purl.obolibrary.org/obo/RO_0002200'})
+        //WITH relation, rows
+        //MATCH path=(subject:genotype)-[:RO:0002200|RO:0002610|RO:0002326|RO:0003302!*2..]->(object:phenotype)
+
+        //WITH rows + COLLECT ({
+        //    path:path,
+        //    relation:relation,
+        //    subject:subject,
+        //    object:object,
+        //    association_type:'genotype_phenotype',
+        //    subject_category:'genotype',
+        //    object_category:'phenotype',
+        //    qualifier:'inferred'
+        //}) as rows
+
+        MATCH (relation:Node{iri:'http://purl.obolibrary.org/obo/RO_0002200'})
+        WITH relation, rows
+        MATCH path=(subject:genotype)<-[:GENO:0000222|RO:0001000*1..2]-(s)-[rels:RO:0002200|RO:0002610|RO:0002326|RO:0003302!*1..2]->(object:phenotype)
+        WHERE NOT ANY (rel in rels where rel.isDefinedBy="https://data.monarchinitiative.org/ttl/udp.ttl")
+
+        WITH rows + COLLECT ({
+            path:path,
+            relation:relation,
+            subject:subject,
+            object:object,
+            association_type:'genotype_phenotype',
+            subject_category:'genotype',
+            object_category:'phenotype',
+            qualifier:'inferred'
+        }) as rows
+
+        UNWIND rows as row
+        RETURN 
+            row.path as path,
+            row.relation as relation,
+            row.subject as subject,
+            row.object as object,
+            row.association_type as association_type,
+            row.subject_category as subject_category,
+            row.object_category as object_category,
+            row.qualifier as qualifier
+
+        ORDER BY subject, object
+
 subject_closure: "equivalentClass|sameAs|type"

--- a/src/main/cypher/golr-loader/literature-disease.yaml
+++ b/src/main/cypher/golr-loader/literature-disease.yaml
@@ -1,37 +1,66 @@
 query: |
         MATCH path=(pub:publication)<-[relation:dc:source]-(association)-[r:OBAN:association_has_object|OBAN:association_has_subject]->(disease:disease)
-        RETURN path, relation,
-            pub as subject,
-            disease as object,
-            'publication_disease' as association_type,
-            'publication' as subject_category,
-            'disease' as object_category,
-            'direct' as qualifier
-        UNION ALL
+
+        WITH COLLECT ({
+            path:path,
+            relation:relation,
+            subject:pub,
+            object:disease,
+            association_type:'publication_disease',
+            subject_category:'publication',
+            object_category:'disease',
+            qualifier:'direct'
+        }) as rows
+
         MATCH path=(pub:publication)-[relation:IAO:0000142|IAO:0000136]->(disease:disease)
-        RETURN path, relation,
-            pub as subject,
-            disease as object,
-            'publication_disease' as association_type,
-            'publication' as subject_category,
-            'disease' as object_category,
-            'direct' as qualifier
-        UNION ALL
+
+        WITH rows + COLLECT ({
+            path:path,
+            relation:relation,
+            subject:pub,
+            object:disease,
+            association_type:'publication_disease',
+            subject_category:'publication',
+            object_category:'disease',
+            qualifier:'direct'
+        }) as rows
+
         MATCH path=(pub:publication)-[relation:IAO:0000142|IAO:0000136]->(model)-[:RO:0003301]->(disease:disease)
-        RETURN path, relation,
-            pub as subject,
-            disease as object,
-            'publication_disease' as association_type,
-            'publication' as subject_category,
-            'disease' as object_category,
-            'indirect' as qualifier
-        UNION ALL
+
+        WITH rows + COLLECT ({
+            path:path,
+            relation:relation,
+            subject:pub,
+            object:disease,
+            association_type:'publication_disease',
+            subject_category:'publication',
+            object_category:'disease',
+            qualifier:'inferred'
+        }) as rows
+
         MATCH path=(pub:publication)<-[relation:dc:source]-(association)-[r:OBAN:association_has_object|OBAN:association_has_subject]->(model)-[:RO:0003301]->(disease:disease)
-        RETURN path, relation,
-            pub as subject,
-            disease as object,
-            'publication_disease' as association_type,
-            'publication' as subject_category,
-            'disease' as object_category,
-            'indirect' as qualifier
+        
+        WITH rows + COLLECT ({
+            path:path,
+            relation:relation,
+            subject:pub,
+            object:disease,
+            association_type:'publication_disease',
+            subject_category:'publication',
+            object_category:'disease',
+            qualifier:'inferred'
+        }) as rows
+
+        UNWIND rows as row
+        RETURN 
+            row.path as path,
+            row.relation as relation,
+            row.subject as subject,
+            row.object as object,
+            row.association_type as association_type,
+            row.subject_category as subject_category,
+            row.object_category as object_category,
+            row.qualifier as qualifier
+        ORDER BY subject, object
+
 subject_closure: "equivalentClass|sameAs|type"

--- a/src/main/cypher/golr-loader/literature-gene.yaml
+++ b/src/main/cypher/golr-loader/literature-gene.yaml
@@ -1,74 +1,96 @@
 query: |
-        MATCH path=(pub:publication)-[relation:IAO:0000142|IAO:0000136]->(x:gene)
-        RETURN path, relation,
-            pub as subject,
-            x as object,
-            'publication_gene' as association_type,
-            'publication' as subject_category,
-            'gene' as object_category,
-            'direct' as qualifier
-        UNION ALL
+        MATCH path=(pub:publication)-[relation:IAO:0000142|IAO:0000136]->(gene:gene)
+
+        WITH COLLECT ({
+            path:path,
+            relation:relation,
+            subject:pub,
+            object:gene,
+            association_type:'publication_gene',
+            subject_category:'publication',
+            object_category:'gene',
+            qualifier:'direct'
+        }) as rows
+
         MATCH path=(pub:publication)<-[relation:dc:source]-(association)-[r:OBAN:association_has_subject|OBAN:association_has_object]->(gene:gene)
-        RETURN path, relation,
-            pub as subject,
-            gene as object,
-            'publication_gene' as association_type,
-            'publication' as subject_category,
-            'gene' as object_category,
-            'direct' as qualifier
-        UNION ALL
+
+        WITH rows + COLLECT ({
+            path:path,
+            relation:relation,
+            subject:pub,
+            object:gene,
+            association_type:'publication_gene',
+            subject_category:'publication',
+            object_category:'gene',
+            qualifier:'direct'
+        }) as rows
+
         MATCH path=(pub:publication)<-[relation:dc:source]-(association)-[r:OBAN:association_has_object|OBAN:association_has_subject]->(genotype:genotype)-[:BFO:0000051!*]->(variant:variant)-[:GENO:0000418!*0..1]->(gene:gene)
-        RETURN path, relation,
-            pub as subject,
-            gene as object,
-            'publication_gene' as association_type,
-            'publication' as subject_category,
-            'gene' as object_category,
-            'indirect' as qualifier
-        UNION ALL
+
+        WITH rows + COLLECT ({
+            path:path,
+            relation:relation,
+            subject:pub,
+            object:gene,
+            association_type:'publication_gene',
+            subject_category:'publication',
+            object_category:'gene',
+            qualifier:'inferred'
+        }) as rows
         MATCH path=(pub:publication)-[relation:IAO:0000142|IAO:0000136]->(genotype:genotype)-[:BFO:0000051!*]->(variant)-[:GENO:0000418!*0..1]->(gene:gene)
-        RETURN path, relation,
-            pub as subject,
-            gene as object,
-            'publication_gene' as association_type,
-            'publication' as subject_category,
-            'gene' as object_category,
-            'inferred' as qualifier
-        UNION ALL
+
+        WITH rows + COLLECT ({
+            path:path,
+            relation:relation,
+            subject:pub,
+            object:gene,
+            association_type:'publication_gene',
+            subject_category:'publication',
+            object_category:'gene',
+            qualifier:'inferred'
+        }) as rows
         MATCH path=(pub:publication)<-[relation:dc:source]-(association)-[r:OBAN:association_has_subject|OBAN:association_has_object]->(variant:variant)-[:GENO:0000418!*0..1]->(gene:gene)
-        RETURN path, relation,
-            pub as subject,
-            gene as object,
-            'publication_gene' as association_type,
-            'publication' as subject_category,
-            'gene' as object_category,
-            'direct' as qualifier
-        UNION ALL
+
+        WITH rows + COLLECT ({
+            path:path,
+            relation:relation,
+            subject:pub,
+            object:gene,
+            association_type:'publication_gene',
+            subject_category:'publication',
+            object_category:'gene',
+            qualifier:'inferred'
+        }) as rows
         MATCH path=(pub:publication)-[relation:IAO:0000142|IAO:0000136]->(variant)-[:GENO:0000418!*0..1]->(gene:gene)
-        RETURN path, relation,
-            pub as subject,
-            gene as object,
-            'publication_gene' as association_type,
-            'publication' as subject_category,
-            'gene' as object_category,
-            'inferred' as qualifier
-        UNION ALL
-        MATCH path=(pub:publication)<-[relation:dc:source]-(association)-[r:OBAN:association_has_subject|OBAN:association_has_object]->(person)-[:GENO:0000222]->(genotype:genotype)-[:BFO:0000051!*]->(variant:variant)-[:GENO:0000418!*0..1]->(gene:gene)
-        RETURN path, relation,
-            pub as subject,
-            gene as object,
-            'publication_gene' as association_type,
-            'publication' as subject_category,
-            'gene' as object_category,
-            'indirect' as qualifier
-        UNION ALL
-        MATCH path=(pub:publication)-[relation:IAO:0000142|IAO:0000136]->(person)-[:GENO:0000222]->(genotype:genotype)-[:BFO:0000051!*]->(variant:variant)-[:GENO:0000418!*0..1]->(gene:gene)
-        RETURN path, relation,
-            pub as subject,
-            gene as object,
-            'publication_gene' as association_type,
-            'publication' as subject_category,
-            'gene' as object_category,
-            'inferred' as qualifier
+
+        WITH rows + COLLECT ({
+            path:path,
+            relation:relation,
+            subject:pub,
+            object:gene,
+            association_type:'publication_gene',
+            subject_category:'publication',
+            object_category:'gene',
+            qualifier:'inferred'
+        }) as rows
+
+        // This query returns 0 results
+        // MATCH path=(pub:publication)<-[relation:dc:source]-(association)-[r:OBAN:association_has_subject|OBAN:association_has_object]->(person)-[:GENO:0000222]->(genotype:genotype)-[:BFO:0000051!*]->(variant:variant)-[:GENO:0000418!*0..1]->(gene:gene)
+
+        // This query returns 0 results
+        // MATCH path=(pub:publication)-[relation:IAO:0000142|IAO:0000136]->(person)-[:GENO:0000222]->(genotype:genotype)-[:BFO:0000051!*]->(variant:variant)-[:GENO:0000418!*0..1]->(gene:gene)
+
+        UNWIND rows as row
+        RETURN 
+            row.path as path,
+            row.relation as relation,
+            row.subject as subject,
+            row.object as object,
+            row.association_type as association_type,
+            row.subject_category as subject_category,
+            row.object_category as object_category,
+            row.qualifier as qualifier
+        ORDER BY subject, object
+
 subject_closure: "equivalentClass|sameAs|type"
 object_closure: "equivalentClass|sameAs|type"

--- a/src/main/cypher/golr-loader/literature-genotype.yaml
+++ b/src/main/cypher/golr-loader/literature-genotype.yaml
@@ -1,38 +1,67 @@
 query: |
         MATCH path=(pub:publication)<-[relation:dc:source]-(association)-[r:OBAN:association_has_object|OBAN:association_has_subject]->(genotype:genotype)
-        RETURN path, relation,
-            pub as subject,
-            genotype as object,
-            'publication_genotype' as association_type,
-            'publication' as subject_category,
-            'genotype' as object_category,
-            'direct' as qualifier
-        UNION ALL
+
+        WITH COLLECT ({
+            path:path,
+            relation:relation,
+            subject:pub,
+            object:genotype,
+            association_type:'publication_genotype',
+            subject_category:'publication',
+            object_category:'genotype',
+            qualifier:'direct'
+        }) as rows
+
         MATCH path=(pub:publication)-[relation:IAO:0000142|IAO:0000136]->(genotype:genotype)
-        RETURN path, relation,
-            pub as subject,
-            genotype as object,
-            'publication_genotype' as association_type,
-            'publication' as subject_category,
-            'genotype' as object_category,
-            'direct' as qualifier
-        UNION ALL
+
+        WITH rows + COLLECT ({
+            path:path,
+            relation:relation,
+            subject:pub,
+            object:genotype,
+            association_type:'publication_genotype',
+            subject_category:'publication',
+            object_category:'genotype',
+            qualifier:'direct'
+        }) as rows
+
         MATCH path=(pub:publication)<-[relation:dc:source]-(association)-[r:OBAN:association_has_object|OBAN:association_has_subject]->(person)-[:GENO:0000222|RO:0001000*1..2]->(genotype:genotype)
-        RETURN path, relation,
-            pub as subject,
-            genotype as object,
-            'publication_genotype' as association_type,
-            'publication' as subject_category,
-            'genotype' as object_category,
-            'indirect' as qualifier
-        UNION ALL
+
+        WITH rows + COLLECT ({
+            path:path,
+            relation:relation,
+            subject:pub,
+            object:genotype,
+            association_type:'publication_genotype',
+            subject_category:'publication',
+            object_category:'genotype',
+            qualifier:'inferred'
+        }) as rows
+
         MATCH path=(pub:publication)-[relation:IAO:0000142|IAO:0000136]->(person)-[:GENO:0000222|RO:0001000*1..2]->(genotype:genotype)
-        RETURN path, relation,
-            pub as subject,
-            genotype as object,
-            'publication_genotype' as association_type,
-            'publication' as subject_category,
-            'genotype' as object_category,
-            'inferred' as qualifier
+
+        WITH rows + COLLECT ({
+            path:path,
+            relation:relation,
+            subject:pub,
+            object:genotype,
+            association_type:'publication_genotype',
+            subject_category:'publication',
+            object_category:'genotype',
+            qualifier:'inferred'
+        }) as rows
+
+        UNWIND rows as row
+        RETURN 
+            row.path as path,
+            row.relation as relation,
+            row.subject as subject,
+            row.object as object,
+            row.association_type as association_type,
+            row.subject_category as subject_category,
+            row.object_category as object_category,
+            row.qualifier as qualifier
+        ORDER BY subject, object
+        
 subject_closure: "equivalentClass|sameAs|type"
 object_closure: "equivalentClass|sameAs|type"

--- a/src/main/cypher/golr-loader/literature-model.yaml
+++ b/src/main/cypher/golr-loader/literature-model.yaml
@@ -1,20 +1,42 @@
 query: |
         MATCH path=(pub:publication)-[relation:IAO:0000142|IAO:0000136]->(model)-[:RO:0003301]->()
-        RETURN path,
-            pub as subject, relation,
-            model as object,
-            'publication_model' as association_type,
-            'publication' as subject_category,
-            'model' as object_category,
-            'direct' as qualifier 
-        UNION ALL
+
+        WITH COLLECT ({
+            path:path,
+            relation:relation,
+            subject:pub,
+            object:model,
+            association_type:'publication_model',
+            subject_category:'publication',
+            object_category:'model',
+            qualifier:'direct'
+        }) as rows
+
+
         MATCH path=(pub:publication)<-[relation:dc:source]-(association)-[r:OBAN:association_has_object|OBAN:association_has_subject]->(model)-[:RO:0003301]->()
-        RETURN path,
-            pub as subject, relation,
-            model as object,
-            'publication_model' as association_type,
-            'publication' as subject_category,
-            'model' as object_category,
-            'direct' as qualifier
+
+        WITH rows + COLLECT ({
+            path:path,
+            relation:relation,
+            subject:pub,
+            object:model,
+            association_type:'publication_model',
+            subject_category:'publication',
+            object_category:'model',
+            qualifier:'direct'
+        }) as rows
+
+        UNWIND rows as row
+        RETURN 
+            row.path as path,
+            row.relation as relation,
+            row.subject as subject,
+            row.object as object,
+            row.association_type as association_type,
+            row.subject_category as subject_category,
+            row.object_category as object_category,
+            row.qualifier as qualifier
+        ORDER BY subject, object
+
 subject_closure: "equivalentClass|sameAs|type"
 object_closure: "equivalentClass|sameAs|type"

--- a/src/main/cypher/golr-loader/literature-phenotype.yaml
+++ b/src/main/cypher/golr-loader/literature-phenotype.yaml
@@ -1,19 +1,29 @@
 query: |
         MATCH path=(pub:publication)<-[relation:dc:source]-(association)-[r:OBAN:association_has_object|OBAN:association_has_subject]->(phenotype:phenotype)
-        RETURN path,
-            pub as subject, relation,
-            phenotype as object,
-            'publication_phenotype' as association_type,
-            'publication' as subject_category,
-            'phenotype' as object_category,
-            'direct' as qualifier
-        UNION ALL
-        MATCH path=(pub:publication)-[relation:IAO:0000142|IAO:0000136]->(phenotype:phenotype)
-        RETURN path,
-            pub as subject, relation,
-            phenotype as object,
-            'publication_phenotype' as association_type,
-            'publication' as subject_category,
-            'phenotype' as object_category,
-            'direct' as qualifier
+        WITH COLLECT ({
+            path:path,
+            relation:relation,
+            subject:pub,
+            object:phenotype,
+            association_type:'publication_phenotype',
+            subject_category:'publication',
+            object_category:'phenotype',
+            qualifier:'direct'
+        }) as rows
+
+        // This query returns 0 rows
+        //MATCH path=(pub:publication)-[relation:IAO:0000142|IAO:0000136]->(phenotype:phenotype)
+
+        UNWIND rows as row
+        RETURN 
+            row.path as path,
+            row.relation as relation,
+            row.subject as subject,
+            row.object as object,
+            row.association_type as association_type,
+            row.subject_category as subject_category,
+            row.object_category as object_category,
+            row.qualifier as qualifier
+        ORDER BY subject, object
+
 subject_closure: "equivalentClass|sameAs|type"

--- a/src/main/cypher/golr-loader/literature-variant.yaml
+++ b/src/main/cypher/golr-loader/literature-variant.yaml
@@ -1,56 +1,80 @@
 query: |
         MATCH path=(pub:publication)<-[relation:dc:source]-(association)-[r:OBAN:association_has_object|OBAN:association_has_subject]->(genotype:genotype)-[:BFO:0000051!*]->(variant:variant)
-        RETURN path,
-            pub as subject, relation,
-            variant as object,
-            'publication_variant' as association_type,
-            'publication' as subject_category,
-            'variant' as object_category,
-            'indirect' as qualifier
-        UNION ALL
+        WITH COLLECT ({
+            path:path,
+            relation:relation,
+            subject:pub,
+            object:variant,
+            association_type:'publication_variant',
+            subject_category:'publication',
+            object_category:'variant',
+            qualifier:'inferred'
+        }) as rows
+
         MATCH path=(pub:publication)-[relation:IAO:0000142|IAO:0000136]->(genotype:genotype)-[:BFO:0000051!*]->(variant:variant)
-        RETURN path,
-            pub as subject, relation,
-            variant as object,
-            'publication_variant' as association_type,
-            'publication' as subject_category,
-            'variant' as object_category,
-            'inferred' as qualifier
-        UNION ALL
+        WITH rows + COLLECT ({
+            path:path,
+            relation:relation,
+            subject:pub,
+            object:variant,
+            association_type:'publication_variant',
+            subject_category:'publication',
+            object_category:'variant',
+            qualifier:'inferred'
+        }) as rows
+
         MATCH path=(pub:publication)<-[relation:dc:source]-(association)-[r:OBAN:association_has_subject|OBAN:association_has_object]->(variant:variant)
-        RETURN path,
-            pub as subject, relation,
-            variant as object,
-            'publication_variant' as association_type,
-            'publication' as subject_category,
-            'variant' as object_category,
-            'direct' as qualifier
-        UNION ALL
+        WITH rows + COLLECT ({
+            path:path,
+            relation:relation,
+            subject:pub,
+            object:variant,
+            association_type:'publication_variant',
+            subject_category:'publication',
+            object_category:'variant',
+            qualifier:'direct'
+        }) as rows
+
         MATCH path=(pub:publication)-[relation:IAO:0000142|IAO:0000136]->(variant)
-        RETURN path,
-            pub as subject, relation,
-            variant as object,
-            'publication_variant' as association_type,
-            'publication' as subject_category,
-            'variant' as object_category,
-            'inferred' as qualifier
-        UNION ALL
-        MATCH path=(pub:publication)<-[relation:dc:source]-(association)-[r:OBAN:association_has_subject|OBAN:association_has_object]->(person)-[:GENO:0000222|RO:0001000*1..2]->(genotype:genotype)-[:BFO:0000051!*]->(variant:variant)
-        RETURN path,
-            pub as subject, relation,
-            variant as object,
-            'publication_variant' as association_type,
-            'publication' as subject_category,
-            'variant' as object_category,
-            'indirect' as qualifier
-        UNION ALL
+        WITH rows + COLLECT ({
+            path:path,
+            relation:relation,
+            subject:pub,
+            object:variant,
+            association_type:'publication_variant',
+            subject_category:'publication',
+            object_category:'variant',
+            qualifier:'inferred'
+        }) as rows
+
+
+        // This query returns 0 rows as of 6/26/2019
+        //MATCH path=(pub:publication)<-[relation:dc:source]-(association)-[r:OBAN:association_has_subject|OBAN:association_has_object]->(person)-[:GENO:0000222|RO:0001000*1..2]->(genotype:genotype)-[:BFO:0000051!*]->(variant:variant)
+
+
         MATCH path=(pub:publication)-[relation:IAO:0000142|IAO:0000136]->(person)-[:GENO:0000222|RO:0001000*1..2]->(genotype:genotype)-[:BFO:0000051!*]->(variant:variant)
-        RETURN path,
-            pub as subject, relation,
-            variant as object,
-            'publication_variant' as association_type,
-            'publication' as subject_category,
-            'variant' as object_category,
-            'inferred' as qualifier
+        WITH rows + COLLECT ({
+            path:path,
+            relation:relation,
+            subject:pub,
+            object:variant,
+            association_type:'publication_variant',
+            subject_category:'publication',
+            object_category:'variant',
+            qualifier:'inferred'
+        }) as rows
+
+        UNWIND rows as row
+        RETURN 
+            row.path as path,
+            row.relation as relation,
+            row.subject as subject,
+            row.object as object,
+            row.association_type as association_type,
+            row.subject_category as subject_category,
+            row.object_category as object_category,
+            row.qualifier as qualifier
+        ORDER BY subject, object
+
 subject_closure: "equivalentClass|sameAs|type"
 object_closure: "equivalentClass|sameAs|type"

--- a/src/main/cypher/golr-loader/marker-disease.yaml
+++ b/src/main/cypher/golr-loader/marker-disease.yaml
@@ -1,28 +1,57 @@
 query: |
         MATCH path=(subject:gene)<-[geno:GENO:0000418|GENO:0000639!*0..1]-(feature)-[relation:RO:0002200|RO:0002610|RO:0002326|RO:0003302!]->(object:disease)
         WHERE NOT (subject)<-[:GENO:0000418|GENO:0000639!*0..1]-()<-[:BFO:0000051!*0..]-()-[:RO:0002200|RO:0003303|GENO:0000840]->(object)
-        RETURN path,
-            subject, object, relation,
-            'marker_disease' as association_type,
-            'gene' AS subject_category,
-            'disease' AS object_category,
-            'inferred through variant' as qualifier
-        UNION ALL
-        MATCH path=(subject:gene)<-[:GENO:0000418|GENO:0000639!]-(variant)<-[:BFO:0000051!*]-(genotype:genotype)-[relation:RO:0002200|RO:0002610|RO:0002326|RO:0003302!]->(object:disease)
-        WHERE NOT (subject)<-[:GENO:0000418|GENO:0000639!*0..1]-()<-[:BFO:0000051!*0..]-()-[:RO:0002200|RO:0003303|GENO:0000840]->(object)
-        RETURN path,
-            subject, object, relation,
-            'marker_disease' as association_type,
-            'gene' AS subject_category,
-            'disease' AS object_category,
-            'inferred through genotype' as qualifier
-        UNION ALL
+
+        WITH COLLECT ({
+            path:path,
+            relation:relation,
+            subject:subject,
+            object:object,
+            association_type:'marker_disease',
+            subject_category:'gene',
+            object_category:'disease',
+            qualifier:'inferred through variant'
+        }) as rows
+        
+        // This query returns 0 rows
+        // MATCH path=(subject:gene)<-[:GENO:0000418|GENO:0000639!]-(variant)<-[:BFO:0000051!*]-(genotype:genotype)-[relation:RO:0002200|RO:0002610|RO:0002326|RO:0003302!]->(object:disease)
+        // WHERE NOT (subject)<-[:GENO:0000418|GENO:0000639!*0..1]-()<-[:BFO:0000051!*0..]-()-[:RO:0002200|RO:0003303|GENO:0000840]->(object)
+        
+        // WITH rows + COLLECT ({
+        //    path:path,
+        //    relation:relation,
+        //    subject:subject,
+        //    object:object,
+        //    association_type:'marker_disease',
+        //    subject_category:'gene',
+        //    object_category:'disease',
+        //    qualifier:'inferred through genotype'
+        // }) as rows
+
         MATCH path=(subject:gene)<-[:GENO:0000418|GENO:0000639!]-(variant)<-[:BFO:0000051!*]-(genotype:genotype)<-[:GENO:0000222|RO:0001000*1..2]-(person)-[relation:RO:0002200!]->(object:disease)
         WHERE NOT (subject)<-[:GENO:0000418|GENO:0000639!*0..1]-()<-[:BFO:0000051!*0..]-()-[:RO:0002200|RO:0003303|GENO:0000840]->(object)
-        RETURN path,
-             subject, object, relation,
-             'marker_disease' as association_type,
-             'gene' AS subject_category,
-             'disease' AS object_category,
-             'inferred through case' as qualifier
+        
+        WITH rows + COLLECT ({
+            path:path,
+            relation:relation,
+            subject:subject,
+            object:object,
+            association_type:'marker_disease',
+            subject_category:'gene',
+            object_category:'disease',
+            qualifier:'inferred through case'
+        }) as rows
+
+        UNWIND rows as row
+        RETURN 
+            row.path as path,
+            row.relation as relation,
+            row.subject as subject,
+            row.object as object,
+            row.association_type as association_type,
+            row.subject_category as subject_category,
+            row.object_category as object_category,
+            row.qualifier as qualifier
+        ORDER BY subject, object
+        
 subject_closure: "equivalentClass|sameAs|type"

--- a/src/main/cypher/golr-loader/model-case.yaml
+++ b/src/main/cypher/golr-loader/model-case.yaml
@@ -1,10 +1,14 @@
 query: |
         MATCH path=(subject)-[relation:RO:0001000]->(object:case)
-        RETURN path,
-        subject, object, relation,
-        'model_case' as association_type,
-        'model' AS subject_category,
-        'case' AS object_category,
-        'direct' AS qualifier
+        RETURN 
+            path,
+            subject,
+            object,
+            relation,
+            'model_case' as association_type,
+            'model' AS subject_category,
+            'case' AS object_category,
+            'direct' AS qualifier
+        ORDER BY subject, object
 subject_closure: "equivalentClass|sameAs|type"
 object_closure: "equivalentClass|sameAs|type"

--- a/src/main/cypher/golr-loader/model-disease.yaml
+++ b/src/main/cypher/golr-loader/model-disease.yaml
@@ -1,9 +1,13 @@
 query: |
         MATCH path=(object:disease)<-[relation:RO:0003301]-(subject)
-        RETURN path,
-        subject, object, relation,
-        'model_disease' as association_type,
-        'model' AS subject_category,
-        'disease' AS object_category,
-        'direct' AS qualifier
+        RETURN 
+            path,
+            subject,
+            object,
+            relation,
+            'model_disease' as association_type,
+            'model' AS subject_category,
+            'disease' AS object_category,
+            'direct' AS qualifier
+        ORDER BY subject, object
 subject_closure: "equivalentClass|sameAs|type"

--- a/src/main/cypher/golr-loader/model-family.yaml
+++ b/src/main/cypher/golr-loader/model-family.yaml
@@ -1,10 +1,14 @@
 query: |
         MATCH path=(subject)-[:RO:0001000]->(person)-[relation:RO:0002350]->(object)-[:type]->(pco:Node{iri:'https://purl.obolibrary.org/obo/PCO_0000020'})
-        RETURN path, relation,
-        subject, object,
-        'model_family' as association_type,
-        'model' AS subject_category,
-        'family' AS object_category,
-        'direct' AS qualifier
+        RETURN 
+            path,
+            relation,
+            subject,
+            object,
+            'model_family' as association_type,
+            'model' AS subject_category,
+            'family' AS object_category,
+            'direct' AS qualifier
+        ORDER BY subject, object
 subject_closure: "equivalentClass|sameAs|type"
 object_closure: "equivalentClass|sameAs|type"

--- a/src/main/cypher/golr-loader/model-gene.yaml
+++ b/src/main/cypher/golr-loader/model-gene.yaml
@@ -1,11 +1,14 @@
 query: |
         MATCH path=(subject)-[:RO:0001000|GENO:0000222*1..2]->(genotype:genotype)-[:BFO:0000051!*]->(variant:variant)-[rel:GENO:0000418|GENO:0000639!*0..1]->(object:gene)
         WHERE NOT ANY (geno_rel in rel where geno_rel.isDefinedBy="https://data.monarchinitiative.org/ttl/udp.ttl")
-        RETURN path,
-        subject, object,
-        'model_gene' as association_type,
-        'model' AS subject_category,
-        'gene' AS object_category,
-        'inferred through genotype' AS qualifier
+        RETURN 
+            path,
+            subject,
+            object,
+            'model_gene' as association_type,
+            'model' AS subject_category,
+            'gene' AS object_category,
+            'inferred through genotype' AS qualifier
+        ORDER BY subject, object
 subject_closure: "equivalentClass|sameAs|type"
 object_closure: "equivalentClass|sameAs|type"

--- a/src/main/cypher/golr-loader/model-genotype.yaml
+++ b/src/main/cypher/golr-loader/model-genotype.yaml
@@ -1,18 +1,41 @@
 query: |
         MATCH path=()<-[:RO:0003301]-(subject)-[relation:GENO:0000222]->(object:genotype)
-        RETURN path,
-        subject, object, relation,
-        'model_genotype' as association_type,
-        'model' AS subject_category,
-        'genotype' AS object_category,
-        'direct' AS qualifier
-        UNION ALL
+
+        WITH COLLECT ({
+            path:path,
+            relation:relation,
+            subject:subject,
+            object:object,
+            association_type:'model_genotype',
+            subject_category:'model',
+            object_category:'genotype',
+            qualifier:'direct'
+        }) as rows
+
         MATCH path=()<-[:RO:0003301]-(subject)-[:RO:0001000]->(organism)-[relation:GENO:0000222]->(object:genotype)
-        RETURN path,
-        subject, object, relation,
-        'model_genotype' as association_type,
-        'model' AS subject_category,
-        'genotype' AS object_category,
-        'direct' AS qualifier
+
+        WITH rows + COLLECT ({
+            path:path,
+            relation:relation,
+            subject:subject,
+            object:object,
+            association_type:'model_genotype',
+            subject_category:'model',
+            object_category:'genotype',
+            qualifier:'direct'
+        }) as rows
+
+        UNWIND rows as row
+        RETURN 
+            row.path as path,
+            row.relation as relation,
+            row.subject as subject,
+            row.object as object,
+            row.association_type as association_type,
+            row.subject_category as subject_category,
+            row.object_category as object_category,
+            row.qualifier as qualifier
+        ORDER BY subject, object
+
 subject_closure: "equivalentClass|sameAs|type"
 object_closure: "equivalentClass|sameAs|type"

--- a/src/main/cypher/golr-loader/model-variant.yaml
+++ b/src/main/cypher/golr-loader/model-variant.yaml
@@ -3,11 +3,15 @@ query: |
         WITH relation
         MATCH path=(subject)-[rel:RO:0001000|GENO:0000222*1..2]->(genotype:genotype)-[:BFO:0000051!*]->(object:variant)
         WHERE NOT ANY (geno_rel in rel where geno_rel.isDefinedBy="https://data.monarchinitiative.org/ttl/udp.ttl")
-        RETURN path, relation,
-        subject, object,
-        'model_variant' as association_type,
-        'model' AS subject_category,
-        'variant' AS object_category,
-        'direct' AS qualifier
+        RETURN 
+            path,
+            relation,
+            subject,
+            object,
+            'model_variant' as association_type,
+            'model' AS subject_category,
+            'variant' AS object_category,
+            'direct' AS qualifier
+        ORDER BY subject, object
 subject_closure: "equivalentClass|sameAs|type"
 object_closure: "equivalentClass|sameAs|type"

--- a/src/main/cypher/golr-loader/pathway-phenotype.yaml
+++ b/src/main/cypher/golr-loader/pathway-phenotype.yaml
@@ -1,30 +1,42 @@
 query: |
-        MATCH path=(pathway:pathway)<-[:RO:0002331]-()<-[:RO:0002205*0..1]-(gene:gene)<-[:GENO:0000418!]-(variant:variant)-[r:RO:0002200|RO:0002610|RO:0002326!*2..]->(phenotype:phenotype)
-        RETURN path,
-        pathway as subject,
-        phenotype as object,
-        r as relation,
-        'pathway_phenotype' as association_type,
-        'pathway' as subject_category,
-        'phenotype' as object_category,
-        'inferred through joining gene pathway, gene disease, and homology associations' as qualifier
-        UNION ALL
-        MATCH path=(pathway:pathway)<-[:RO:0002331]-()<-[:RO:0002205*0..1]-(gene:gene)<-[:GENO:0000418!]-(variant:variant)<-[:BFO:0000051!*]-(genotype:genotype)-[r:RO:0002200|RO:0002610|RO:0002326!*2..]->(phenotype:phenotype)
-        RETURN path,
-        pathway as subject,
-        phenotype as object,
-        r as relation,
-        'pathway_phenotype' as association_type,
-        'pathway' as subject_category,
-        'phenotype' as object_category,
-        'inferred through joining gene pathway, gene disease, and homology associations' as qualifier
-        UNION ALL
-        MATCH path=(pathway:pathway)<-[:RO:0002331]-()<-[:RO:0002205*0..1]-(gene:gene)<-[:GENO:0000418!]-(variant:variant)<-[:BFO:0000051!*]-(genotype:genotype)<-[:GENO:0000222|RO:0001000*1..2]-(person)-[r:RO:0002200|RO:0002610|RO:0002326!*2..]->(phenotype:phenotype)
-        RETURN path,
-        pathway as subject,
-        phenotype as object,
-        r as relation,
-        'pathway_phenotype' as association_type,
-        'pathway' as subject_category,
-        'phenotype' as object_category,
-        'inferred through joining gene pathway, gene disease, and homology associations' as qualifier
+        MATCH path=(subject:pathway)<-[:RO:0002331]-()<-[:RO:0002205*0..1]-(gene:gene)<-[:GENO:0000418!]-(variant:variant)-[relation:RO:0002200|RO:0002610|RO:0002326!*2..]->(object:phenotype)
+
+        WITH COLLECT ({
+            path:path,
+            relation:relation,
+            subject:subject,
+            object:object,
+            association_type:'pathway_phenotype',
+            subject_category:'pathway',
+            object_category:'phenotype',
+            qualifier:'inferred through joining gene pathway, variant disease, and disease phenotype'
+        }) as rows
+        
+        // returns 0 results
+        // MATCH path=(subject:pathway)<-[:RO:0002331]-()<-[:RO:0002205*0..1]-(gene:gene)<-[:GENO:0000418!]-(variant:variant)<-[:BFO:0000051!*]-(genotype:genotype)-[relation:RO:0002200|RO:0002610|RO:0002326!*2..]->(object:phenotype)
+
+        MATCH path=(subject:pathway)<-[:RO:0002331]-()<-[:RO:0002205*0..1]-(gene:gene)<-[:GENO:0000418!]-(variant:variant)<-[:BFO:0000051!*]-(genotype:genotype)<-[:GENO:0000222|RO:0001000*1..2]-(person)-[relation:RO:0002200|RO:0002610|RO:0002326!*2..]->(object:phenotype)
+
+        WITH rows + COLLECT ({
+            path:path,
+            relation:relation,
+            subject:subject,
+            object:object,
+            association_type:'pathway_phenotype',
+            subject_category:'pathway',
+            object_category:'phenotype',
+            qualifier:'inferred'
+        }) as rows
+
+        UNWIND rows as row
+        RETURN 
+            row.path as path,
+            row.relation as relation,
+            row.subject as subject,
+            row.object as object,
+            row.association_type as association_type,
+            row.subject_category as subject_category,
+            row.object_category as object_category,
+            row.qualifier as qualifier
+        ORDER BY subject, object
+

--- a/src/main/cypher/golr-loader/variant-disease.yaml
+++ b/src/main/cypher/golr-loader/variant-disease.yaml
@@ -1,25 +1,53 @@
 query: |
         MATCH path=(subject:variant)-[relation:RO:0002200|RO:0002610|RO:0002326|RO:0003302!]->(object:disease)
-        RETURN path,
-        subject, object, relation,
-        'variant_disease' as association_type,
-        'variant' AS subject_category,
-        'disease' AS object_category,
-        'direct' as qualifier
-        UNION ALL
+
+        WITH COLLECT ({
+            path:path,
+            relation:relation,
+            subject:subject,
+            object:object,
+            association_type:'variant_disease',
+            subject_category:'variant',
+            object_category:'disease',
+            qualifier:'direct'
+        }) as rows
+
         MATCH path=(subject:variant)<-[:BFO:0000051!*]-(genotype:genotype)-[relation:RO:0002200|RO:0002610|RO:0002326|RO:0003302!]->(object:disease)
-        RETURN path,
-        subject, object, relation,
-        'variant_disease' as association_type,
-        'variant' AS subject_category,
-        'disease' AS object_category,
-        'inferred' as qualifier
-        UNION ALL
+
+        WITH rows + COLLECT ({
+            path:path,
+            relation:relation,
+            subject:subject,
+            object:object,
+            association_type:'variant_disease',
+            subject_category:'variant',
+            object_category:'disease',
+            qualifier:'inferred'
+        }) as rows
+
         MATCH path=(subject:variant)<-[:BFO:0000051!*]-(genotype:genotype)<-[:RO:0001000|GENO:0000222*1..2]-(organism)-[relation:RO:0002200|RO:0002610|RO:0002326!]->(object:disease)
-        RETURN path,
-        subject, object, relation,
-        'variant_disease' as association_type,
-        'variant' AS subject_category,
-        'disease' AS object_category,
-        'inferred' as qualifier
+
+        WITH rows + COLLECT ({
+            path:path,
+            relation:relation,
+            subject:subject,
+            object:object,
+            association_type:'variant_disease',
+            subject_category:'variant',
+            object_category:'disease',
+            qualifier:'inferred'
+        }) as rows
+
+        UNWIND rows as row
+        RETURN 
+            row.path as path,
+            row.relation as relation,
+            row.subject as subject,
+            row.object as object,
+            row.association_type as association_type,
+            row.subject_category as subject_category,
+            row.object_category as object_category,
+            row.qualifier as qualifier
+        ORDER BY subject, object
+
 subject_closure: "equivalentClass|sameAs|type"

--- a/src/main/cypher/golr-loader/variant-gene.yaml
+++ b/src/main/cypher/golr-loader/variant-gene.yaml
@@ -1,10 +1,14 @@
 query: |
         MATCH path=(subject:variant)<-[optional:GENO:0000382*0..1]-()-[relation:GENO:0000418|GENO:0000639!]->(object:gene)
-        RETURN path,
-        subject, object, relation,
-        'variant_gene' as association_type,
-        'variant' AS subject_category,
-        'gene' AS object_category,
-        'direct' AS qualifier
+        RETURN 
+            path,
+            subject,
+            object,
+            relation,
+            'variant_gene' as association_type,
+            'variant' AS subject_category,
+            'gene' AS object_category,
+            'direct' AS qualifier
+        ORDER BY subject, object
 subject_closure: "equivalentClass|sameAs|type"
 object_closure: "equivalentClass|sameAs|type"

--- a/src/main/cypher/golr-loader/variant-genotype.yaml
+++ b/src/main/cypher/golr-loader/variant-genotype.yaml
@@ -1,10 +1,14 @@
 query: |
         MATCH path=(object:genotype)-[relation:BFO:0000051!*]->(subject:variant)
-        RETURN path,
-        subject, object, relation,
-        'variant_genotype' as association_type,
-        'variant' AS subject_category,
-        'genotype' AS object_category,
-        'inferred' AS qualifier
+        RETURN 
+            path,
+            subject,
+            object,
+            relation,
+            'variant_genotype' as association_type,
+            'variant' AS subject_category,
+            'genotype' AS object_category,
+            'direct' AS qualifier
+        ORDER BY subject, object
 subject_closure: "equivalentClass|sameAs|type"
 object_closure: "equivalentClass|sameAs|type"

--- a/src/main/cypher/golr-loader/variant-phenotype.yaml
+++ b/src/main/cypher/golr-loader/variant-phenotype.yaml
@@ -1,36 +1,72 @@
 query: |
+        // Direct variant to phenotype
         MATCH path=(subject:variant)-[relation:RO:0002200|RO:0002610|RO:0002326|RO:0003302!]->(object:phenotype)
-        RETURN path,
-        subject, object, relation,
-        'variant_phenotype' as association_type,
-        'variant' AS subject_category,
-        'phenotype' AS object_category,
-        'direct' as qualifier
-        UNION ALL
+        WITH COLLECT ({
+            path:path,
+            relation:relation,
+            subject:subject,
+            object:object,
+            association_type:'variant_phenotype',
+            subject_category:'variant',
+            object_category:'phenotype',
+            qualifier:'direct'
+        }) as rows
+
+        // Variant to phenotype inferred via disease-phenotype
         MATCH (relation:Node{iri:'http://purl.obolibrary.org/obo/RO_0002200'})
-        WITH relation
+        WITH relation, rows
         MATCH path=(subject:variant)-[:RO:0002200|RO:0002610|RO:0002326|RO:0003302!*2..2]->(object:phenotype)
-        RETURN path,
-        subject, object, relation,
-        'variant_phenotype' as association_type,
-        'variant' AS subject_category,
-        'phenotype' AS object_category,
-        'inferred through disease' as qualifier
-        UNION ALL
+
+        WITH rows + COLLECT ({
+            path:path,
+            relation:relation,
+            subject:subject,
+            object:object,
+            association_type:'variant_phenotype',
+            subject_category:'variant',
+            object_category:'phenotype',
+            qualifier:'inferred through disease'
+        }) as rows
+
+        // Variant to phenotype inferred via genotype
         MATCH path=(subject:variant)<-[:BFO:0000051!*]-(genotype)-[relation:RO:0002200|RO:0002610|RO:0002326|RO:0003302!]->(object:phenotype)
-        RETURN path,
-        subject, object, relation,
-        'variant_phenotype' as association_type,
-        'variant' AS subject_category,
-        'phenotype' AS object_category,
-        'inferred through genotype' as qualifier
-        UNION ALL
+
+        WITH rows + COLLECT ({
+            path:path,
+            relation:relation,
+            subject:subject,
+            object:object,
+            association_type:'variant_phenotype',
+            subject_category:'variant',
+            object_category:'phenotype',
+            qualifier:'inferred through genotype'
+        }) as rows
+
+        // Variant to phenotype inferred via genotype and model
         MATCH path=(subject:variant)<-[:BFO:0000051!*]-(genotype)<-[:RO:0001000|GENO:0000222*1..2]-(organism)-[relation:RO:0002200|RO:0002610|RO:0002326!]->(object:phenotype)
         WHERE NOT relation.isDefinedBy="https://data.monarchinitiative.org/ttl/udp.ttl"
-        RETURN path,
-        subject, object, relation,
-        'variant_phenotype' as association_type,
-        'variant' AS subject_category,
-        'phenotype' AS object_category,
-        'inferred through model' as qualifier
+
+        WITH rows + COLLECT ({
+            path:path,
+            relation:relation,
+            subject:subject,
+            object:object,
+            association_type:'variant_phenotype',
+            subject_category:'variant',
+            object_category:'phenotype',
+            qualifier:'inferred through model'
+        }) as rows
+
+        UNWIND rows as row
+        RETURN 
+            row.path as path,
+            row.relation as relation,
+            row.subject as subject,
+            row.object as object,
+            row.association_type as association_type,
+            row.subject_category as subject_category,
+            row.object_category as object_category,
+            row.qualifier as qualifier
+        ORDER BY subject, object
+
 subject_closure: "equivalentClass|sameAs|type"


### PR DESCRIPTION
Replaces UNION queries with COLLECT in order to sort the results, see https://neo4j.com/blog/cypher-union-query-using-collect-clause/

Note that a downside of this is that if any path returns 0 rows the whole query returns 0 rows.  I ran into a handful of our path patterns that return 0 rows and commented them out.  We'll likely want to circle back to figure out why these are no longer returning data.

See https://github.com/SciGraph/golr-loader/pull/48