### PR TITLE
Remove literature-x paths for latest release

### DIFF
--- a/src/main/cypher/golr-loader/literature-gene.yaml
+++ b/src/main/cypher/golr-loader/literature-gene.yaml
@@ -37,18 +37,10 @@ query: |
             object_category:'gene',
             qualifier:'inferred'
         }) as rows
-        MATCH path=(pub:publication)-[relation:IAO:0000142|IAO:0000136]->(genotype:genotype)-[:BFO:0000051!*]->(variant)-[:GENO:0000418!*0..1]->(gene:gene)
 
-        WITH rows + COLLECT ({
-            path:path,
-            relation:relation,
-            subject:pub,
-            object:gene,
-            association_type:'publication_gene',
-            subject_category:'publication',
-            object_category:'gene',
-            qualifier:'inferred'
-        }) as rows
+        // No rows as of 07 2019 ttl release
+        // MATCH path=(pub:publication)-[relation:IAO:0000142|IAO:0000136]->(genotype:genotype)-[:BFO:0000051!*]->(variant)-[:GENO:0000418!*0..1]->(gene:gene)
+
         MATCH path=(pub:publication)<-[relation:dc:source]-(association)-[r:OBAN:association_has_subject|OBAN:association_has_object]->(variant:variant)-[:GENO:0000418!*0..1]->(gene:gene)
 
         WITH rows + COLLECT ({

--- a/src/main/cypher/golr-loader/literature-genotype.yaml
+++ b/src/main/cypher/golr-loader/literature-genotype.yaml
@@ -12,18 +12,8 @@ query: |
             qualifier:'direct'
         }) as rows
 
-        MATCH path=(pub:publication)-[relation:IAO:0000142|IAO:0000136]->(genotype:genotype)
-
-        WITH rows + COLLECT ({
-            path:path,
-            relation:relation,
-            subject:pub,
-            object:genotype,
-            association_type:'publication_genotype',
-            subject_category:'publication',
-            object_category:'genotype',
-            qualifier:'direct'
-        }) as rows
+        // No rows as of 07 2019 ttl release
+        // MATCH path=(pub:publication)-[relation:IAO:0000142|IAO:0000136]->(genotype:genotype)
 
         MATCH path=(pub:publication)<-[relation:dc:source]-(association)-[r:OBAN:association_has_object|OBAN:association_has_subject]->(person)-[:GENO:0000222|RO:0001000*1..2]->(genotype:genotype)
 

--- a/src/main/cypher/golr-loader/literature-variant.yaml
+++ b/src/main/cypher/golr-loader/literature-variant.yaml
@@ -11,17 +11,8 @@ query: |
             qualifier:'inferred'
         }) as rows
 
-        MATCH path=(pub:publication)-[relation:IAO:0000142|IAO:0000136]->(genotype:genotype)-[:BFO:0000051!*]->(variant:variant)
-        WITH rows + COLLECT ({
-            path:path,
-            relation:relation,
-            subject:pub,
-            object:variant,
-            association_type:'publication_variant',
-            subject_category:'publication',
-            object_category:'variant',
-            qualifier:'inferred'
-        }) as rows
+        // No rows as of 07 2019 ttl release
+        //MATCH path=(pub:publication)-[relation:IAO:0000142|IAO:0000136]->(genotype:genotype)-[:BFO:0000051!*]->(variant:variant)
 
         MATCH path=(pub:publication)<-[relation:dc:source]-(association)-[r:OBAN:association_has_subject|OBAN:association_has_object]->(variant:variant)
         WITH rows + COLLECT ({


### PR DESCRIPTION
MATCH path=(pub:publication)-[relation:IAO:0000142|IAO:0000136]->(genotype:genotype) returns 0 rows with the flybase updates